### PR TITLE
fix(deploy): sync Supabase env vars from GitHub secrets to Vercel before build

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -31,8 +31,31 @@ jobs:
       - name: Pull Vercel environment (production)
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
+      # Sync Supabase vars from GitHub secrets → Vercel Production so they are
+      # available both at build time (baked into NEXT_PUBLIC_ bundle) and at
+      # runtime (process.env inside Server Components / Server Actions).
+      - name: Sync Supabase env vars to Vercel
+        run: |
+          if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
+            echo "WARNING: NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY secret is not set."
+            echo "Add them as GitHub repository secrets. Skipping Vercel env sync."
+            exit 0
+          fi
+          # Remove then re-add to handle "already exists" cleanly.
+          vercel env rm NEXT_PUBLIC_SUPABASE_URL production --yes --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null || true
+          echo "$NEXT_PUBLIC_SUPABASE_URL" | vercel env add NEXT_PUBLIC_SUPABASE_URL production --token=${{ secrets.VERCEL_TOKEN }}
+
+          vercel env rm NEXT_PUBLIC_SUPABASE_ANON_KEY production --yes --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null || true
+          echo "$NEXT_PUBLIC_SUPABASE_ANON_KEY" | vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
       - name: Build project (Vercel)
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Deploy to production
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem

Production site at https://neighborswap.vercel.app/ returns HTTP 500 on every route that calls `createClient()`:

```
Error: Your project's URL and Key are required to create a Supabase client!
```

Root cause: `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` were never added to the Vercel project's **Production** environment settings. The `vercel pull` step only downloads what's already there — if the vars are missing, the deployed serverless functions get `undefined` at runtime.

## Fix

1. **Sync step** — before building, the workflow now pushes both vars from GitHub repository secrets directly into the Vercel Production environment via `vercel env add`. This ensures they are available at runtime in Server Components and Server Actions.

2. **Build-time env** — passes the vars explicitly to `vercel build` so they are baked into the `NEXT_PUBLIC_` client bundle as well.

3. **Graceful skip** — if the GitHub secrets aren't set, the sync step prints a warning and exits 0 (no secrets → no crash).

## Required one-time setup

Before merging, add these two GitHub repository secrets (**Settings → Secrets and variables → Actions → New repository secret**):

| Name | Value |
|------|-------|
| `NEXT_PUBLIC_SUPABASE_URL` | Your Supabase project URL (e.g. `https://xxxx.supabase.co`) |
| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Your Supabase anon/public key |

Both values are in **Supabase Dashboard → Project → Settings → API**.

## Test plan

- [ ] Add the two GitHub secrets
- [ ] Merge this PR → production deploy workflow runs
- [ ] "Sync Supabase env vars to Vercel" step succeeds
- [ ] https://neighborswap.vercel.app/ loads without 500 error
- [ ] `/listings`, `/trades`, `/profile` all load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)