### PR TITLE
feat(trades): enforce transaction state machine constraints in DB and API

### DIFF
--- a/src/actions/__tests__/trades.test.ts
+++ b/src/actions/__tests__/trades.test.ts
@@ -1,120 +1,333 @@
 // src/actions/__tests__/trades.test.ts
-// Unit tests for createTradeAction.
+// Unit tests for createTradeAction and updateTradeStatusAction.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 const mockGetUser = vi.fn()
-const mockSingle = vi.fn()
-const mockSelect = vi.fn().mockReturnValue({ single: mockSingle })
-const mockInsert = vi.fn().mockReturnValue({ select: mockSelect })
+const mockEmitToRoom = vi.fn()
+const mockRedirect = vi.fn()
+
+// createTradeAction chain: from('trades').insert({}).select('id').single()
+const mockInsertSingle = vi.fn()
+const mockInsertSelect = vi.fn().mockReturnValue({ single: mockInsertSingle })
+const mockInsert = vi.fn().mockReturnValue({ select: mockInsertSelect })
+
+// updateTradeStatusAction — fetch: from('trades').select('...').eq().single()
+const mockFetchSingle = vi.fn()
+const mockFetchEq = vi.fn().mockReturnValue({ single: mockFetchSingle })
+const mockFetchSelect = vi.fn().mockReturnValue({ eq: mockFetchEq })
+
+// updateTradeStatusAction — update: from('trades').update({}).eq()
+const mockUpdateEq = vi.fn()
+const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq })
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: { getUser: mockGetUser },
-    from: vi.fn().mockReturnValue({ insert: mockInsert }),
+    from: vi.fn().mockReturnValue({
+      insert: mockInsert,
+      select: mockFetchSelect,
+      update: mockUpdate,
+    }),
   }),
 }))
 
-const mockRedirect = vi.fn()
-vi.mock('next/navigation', () => ({
-  redirect: mockRedirect,
-}))
+vi.mock('@/lib/socket/emitter', () => ({ emitToRoom: mockEmitToRoom }))
+vi.mock('next/navigation', () => ({ redirect: mockRedirect }))
 
 // Lazy import AFTER mocks are hoisted
-const { createTradeAction } = await import('../trades')
+const { createTradeAction, updateTradeStatusAction } = await import('../trades')
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Fixtures ──────────────────────────────────────────────────────────────────
 
 function makeFormData(fields: Record<string, string>): FormData {
   const fd = new FormData()
-  for (const [key, value] of Object.entries(fields)) {
-    fd.append(key, value)
-  }
+  for (const [key, value] of Object.entries(fields)) fd.append(key, value)
   return fd
 }
 
-const prevState = { error: null }
-const AUTHED_USER = { id: 'user-initiator-123' }
-const ITEM_ID = 'item-abc-456'
-const COUNTERPARTY_ID = 'user-provider-789'
+const CREATE_PREV_STATE = { error: null }
+
+// createTradeAction fixtures
+const CREATE_USER = { id: 'user-initiator-123' }
+const CREATE_ITEM_ID = 'item-abc-456'
+const CREATE_COUNTERPARTY_ID = 'user-provider-789'
 const NEW_TRADE_ID = 'trade-new-1'
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// updateTradeStatusAction fixtures
+const TRADE_ID = 'trade-uuid-001'
+const INITIATOR_ID = 'user-initiator-001'
+const COUNTERPARTY_ID = 'user-counterparty-001'
+
+function makeTrade(status = 'pending_offer') {
+  return { status, initiator_id: INITIATOR_ID, counterparty_id: COUNTERPARTY_ID }
+}
+
+// ── createTradeAction ─────────────────────────────────────────────────────────
 
 describe('createTradeAction', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetUser.mockResolvedValue({ data: { user: AUTHED_USER }, error: null })
-    mockSingle.mockResolvedValue({ data: { id: NEW_TRADE_ID }, error: null })
+    mockGetUser.mockResolvedValue({ data: { user: CREATE_USER }, error: null })
+    mockInsertSingle.mockResolvedValue({ data: { id: NEW_TRADE_ID }, error: null })
   })
-
-  // ── Auth ───────────────────────────────────────────────────────────────────
 
   it('returns error when user is not authenticated', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null })
-
-    const fd = makeFormData({ item_id: ITEM_ID, counterparty_id: COUNTERPARTY_ID })
-    const result = await createTradeAction(prevState, fd)
-
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
     expect(result.error).toMatch(/signed in/i)
     expect(mockInsert).not.toHaveBeenCalled()
   })
 
-  // ── Validation ─────────────────────────────────────────────────────────────
-
   it('returns error when item_id is missing', async () => {
-    const fd = makeFormData({ counterparty_id: COUNTERPARTY_ID })
-    const result = await createTradeAction(prevState, fd)
-
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
     expect(result.error).toMatch(/item/i)
     expect(mockInsert).not.toHaveBeenCalled()
   })
 
   it('returns error when counterparty_id is missing', async () => {
-    const fd = makeFormData({ item_id: ITEM_ID })
-    const result = await createTradeAction(prevState, fd)
-
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID })
+    )
     expect(result.error).toMatch(/provider/i)
     expect(mockInsert).not.toHaveBeenCalled()
   })
 
   it('returns error when initiator and counterparty are the same user', async () => {
-    const fd = makeFormData({ item_id: ITEM_ID, counterparty_id: AUTHED_USER.id })
-    const result = await createTradeAction(prevState, fd)
-
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_USER.id })
+    )
     expect(result.error).toMatch(/yourself/i)
     expect(mockInsert).not.toHaveBeenCalled()
   })
 
-  // ── DB ─────────────────────────────────────────────────────────────────────
-
   it('returns error when DB insert fails', async () => {
-    mockSingle.mockResolvedValue({ data: null, error: { message: 'RLS violation' } })
-
-    const fd = makeFormData({ item_id: ITEM_ID, counterparty_id: COUNTERPARTY_ID })
-    const result = await createTradeAction(prevState, fd)
-
+    mockInsertSingle.mockResolvedValue({ data: null, error: { message: 'RLS violation' } })
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
     expect(result.error).toMatch(/failed to create/i)
     expect(mockRedirect).not.toHaveBeenCalled()
   })
 
   it('inserts correct fields into trades table', async () => {
-    const fd = makeFormData({ item_id: ITEM_ID, counterparty_id: COUNTERPARTY_ID })
-    await createTradeAction(prevState, fd)
-
-    const insertPayload = mockInsert.mock.calls[0][0]
-    expect(insertPayload.initiator_id).toBe(AUTHED_USER.id)
-    expect(insertPayload.counterparty_id).toBe(COUNTERPARTY_ID)
-    expect(insertPayload.item_id).toBe(ITEM_ID)
-    expect(insertPayload.status).toBe('pending_offer')
+    await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
+    const payload = mockInsert.mock.calls[0][0]
+    expect(payload.initiator_id).toBe(CREATE_USER.id)
+    expect(payload.counterparty_id).toBe(CREATE_COUNTERPARTY_ID)
+    expect(payload.item_id).toBe(CREATE_ITEM_ID)
+    expect(payload.status).toBe('pending_offer')
   })
 
   it('redirects to /chat/[tradeId] on success', async () => {
-    const fd = makeFormData({ item_id: ITEM_ID, counterparty_id: COUNTERPARTY_ID })
-    await createTradeAction(prevState, fd)
-
+    await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
     expect(mockRedirect).toHaveBeenCalledWith(`/chat/${NEW_TRADE_ID}`)
+  })
+})
+
+// ── updateTradeStatusAction ───────────────────────────────────────────────────
+
+describe('updateTradeStatusAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: authenticated as initiator
+    mockGetUser.mockResolvedValue({ data: { user: { id: INITIATOR_ID } } })
+    // Default trade: negotiating (middle of flow, allows many transitions)
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('negotiating'), error: null })
+    mockUpdateEq.mockResolvedValue({ error: null })
+  })
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+
+  it('returns error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/not authenticated/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Trade lookup ────────────────────────────────────────────────────────────
+
+  it('returns error when trade is not found', async () => {
+    mockFetchSingle.mockResolvedValue({ data: null, error: { message: 'not found' } })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/trade not found/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns error when user is not a party to the trade', async () => {
+    mockFetchSingle.mockResolvedValue({
+      data: { status: 'negotiating', initiator_id: 'other-1', counterparty_id: 'other-2' },
+      error: null,
+    })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/not authorized/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── State machine validation ────────────────────────────────────────────────
+
+  it('returns error when transitioning from a terminal status', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('completed'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(result.error).toMatch(/cannot transition/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns error for an invalid transition path (pending_offer → completed)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'completed')
+    expect(result.error).toMatch(/cannot transition/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns error for an invalid transition path (in_progress → accepted)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/cannot transition/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Role-based permission ───────────────────────────────────────────────────
+
+  it('returns error when initiator tries to start negotiating (counterparty-only)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    // mockGetUser already returns INITIATOR_ID
+    const result = await updateTradeStatusAction(TRADE_ID, 'negotiating')
+    expect(result.error).toMatch(/counterparty/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('allows the counterparty to start negotiating', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'negotiating')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows the initiator to cancel from pending_offer', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows the initiator to accept from negotiating', async () => {
+    // mockFetchSingle default is 'negotiating'
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows the counterparty to accept from negotiating', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows both parties to mark in_progress from accepted', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows both parties to mark completed from in_progress', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'completed')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows both parties to dispute from in_progress', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'disputed')
+    expect(result.error).toBeNull()
+  })
+
+  // ── Lifecycle timestamps ────────────────────────────────────────────────────
+
+  it('sets accepted_at when transitioning to accepted', async () => {
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toBeNull()
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.accepted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('sets completed_at when transitioning to completed', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'completed')
+    expect(result.error).toBeNull()
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.completed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('sets cancelled_at when transitioning to cancelled', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    expect(result.error).toBeNull()
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.cancelled_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('does not set lifecycle timestamps for non-milestone transitions', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.accepted_at).toBeUndefined()
+    expect(payload.completed_at).toBeUndefined()
+    expect(payload.cancelled_at).toBeUndefined()
+  })
+
+  // ── DB failure ──────────────────────────────────────────────────────────────
+
+  it('returns error when DB update fails', async () => {
+    mockUpdateEq.mockResolvedValue({ error: { message: 'constraint violation' } })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/failed to update/i)
+    expect(mockEmitToRoom).not.toHaveBeenCalled()
+  })
+
+  // ── Socket emission ─────────────────────────────────────────────────────────
+
+  it('emits the trade status event after a successful update', async () => {
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(mockEmitToRoom).toHaveBeenCalledOnce()
+    const [room, , payload] = mockEmitToRoom.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ]
+    expect(room).toBe(`trade:${TRADE_ID}`)
+    expect(payload.trade_id).toBe(TRADE_ID)
+    expect(payload.status).toBe('accepted')
+    expect(payload.updated_at as string).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('does not emit when DB update fails', async () => {
+    mockUpdateEq.mockResolvedValue({ error: { message: 'error' } })
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(mockEmitToRoom).not.toHaveBeenCalled()
+  })
+
+  // ── Update payload ──────────────────────────────────────────────────────────
+
+  it('includes the correct status in the DB update payload', async () => {
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.status).toBe('accepted')
   })
 })

--- a/src/actions/trades.ts
+++ b/src/actions/trades.ts
@@ -7,7 +7,8 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { emitToRoom } from '@/lib/socket/emitter'
 import { SOCKET_EVENTS } from '@/lib/socket'
-import type { TradeStatus } from '@/types/trades'
+import { VALID_TRANSITIONS } from '@/types/trades'
+import type { TradeStatus, TransitionRole } from '@/types/trades'
 
 export interface CreateTradeResult {
   error: string | null
@@ -52,7 +53,7 @@ export interface UpdateTradeStatusResult {
 
 export async function updateTradeStatusAction(
   tradeId: string,
-  status: TradeStatus
+  newStatus: TradeStatus
 ): Promise<UpdateTradeStatusResult> {
   const supabase = await createClient()
 
@@ -63,24 +64,46 @@ export async function updateTradeStatusAction(
 
   const { data: trade } = await supabase
     .from('trades')
-    .select('initiator_id, counterparty_id')
+    .select('status, initiator_id, counterparty_id')
     .eq('id', tradeId)
     .single()
 
   if (!trade) return { error: 'Trade not found.' }
-  if (trade.initiator_id !== user.id && trade.counterparty_id !== user.id) {
-    return { error: 'Not authorized.' }
+
+  const isInitiator = trade.initiator_id === user.id
+  const isCounterparty = trade.counterparty_id === user.id
+  if (!isInitiator && !isCounterparty) return { error: 'Not authorized.' }
+
+  // Validate state machine transition
+  const currentStatus = trade.status as TradeStatus
+  const allowedTransitions = VALID_TRANSITIONS[currentStatus] ?? []
+  const transition = allowedTransitions.find((t) => t.next === newStatus)
+
+  if (!transition) {
+    return { error: `Cannot transition from '${currentStatus}' to '${newStatus}'.` }
   }
 
-  const updated_at = new Date().toISOString()
-  const { error } = await supabase.from('trades').update({ status, updated_at }).eq('id', tradeId)
+  // Validate role permission for this specific transition
+  const role: TransitionRole = isInitiator ? 'initiator' : 'counterparty'
+  if (!transition.roles.includes(role)) {
+    return { error: `Only the ${transition.roles.join(' or ')} can perform this transition.` }
+  }
+
+  // Build update payload; set lifecycle timestamps for key milestones
+  const now = new Date().toISOString()
+  const updatePayload: Record<string, unknown> = { status: newStatus }
+  if (newStatus === 'accepted') updatePayload.accepted_at = now
+  if (newStatus === 'completed') updatePayload.completed_at = now
+  if (newStatus === 'cancelled') updatePayload.cancelled_at = now
+
+  const { error } = await supabase.from('trades').update(updatePayload).eq('id', tradeId)
 
   if (error) return { error: 'Failed to update trade status.' }
 
   emitToRoom(`trade:${tradeId}`, SOCKET_EVENTS.tradeStatus(tradeId), {
     trade_id: tradeId,
-    status,
-    updated_at,
+    status: newStatus,
+    updated_at: now,
   })
 
   return { error: null }

--- a/src/types/trades.ts
+++ b/src/types/trades.ts
@@ -26,6 +26,47 @@ export const TERMINAL_STATUSES = [
 export type TerminalTradeStatus = (typeof TERMINAL_STATUSES)[number]
 
 // ---------------------------------------------------------------------------
+// State machine — valid user-initiated transitions, enforced server-side
+// in updateTradeStatusAction and at the DB level via the
+// validate_trade_transition trigger.
+//
+// Agent-initiated transitions (accepted → flagged, accepted → scheduled)
+// are excluded here; those go through dedicated Server Actions.
+//
+// Maps to the 4 user-visible milestones from the PRD:
+//   INQUIRY phase  → pending_offer / negotiating
+//   REQUESTED      → accepted
+//   PICKED_UP      → in_progress
+//   RETURNED       → completed
+// ---------------------------------------------------------------------------
+export type TransitionRole = 'initiator' | 'counterparty'
+
+export interface ValidTransition {
+  next: TradeStatus
+  roles: TransitionRole[]
+}
+
+export const VALID_TRANSITIONS: Partial<Record<TradeStatus, ValidTransition[]>> = {
+  pending_offer: [
+    { next: 'negotiating', roles: ['counterparty'] },
+    { next: 'cancelled', roles: ['initiator', 'counterparty'] },
+  ],
+  negotiating: [
+    { next: 'accepted', roles: ['initiator', 'counterparty'] },
+    { next: 'cancelled', roles: ['initiator', 'counterparty'] },
+  ],
+  accepted: [
+    { next: 'in_progress', roles: ['initiator', 'counterparty'] },
+    { next: 'disputed', roles: ['initiator', 'counterparty'] },
+  ],
+  scheduled: [{ next: 'in_progress', roles: ['initiator', 'counterparty'] }],
+  in_progress: [
+    { next: 'completed', roles: ['initiator', 'counterparty'] },
+    { next: 'disputed', roles: ['initiator', 'counterparty'] },
+  ],
+}
+
+// ---------------------------------------------------------------------------
 // LogisticsData — typed shape of the logistics_data JSONB column.
 // Produced by src/lib/agents/logistics.ts.
 // ---------------------------------------------------------------------------

--- a/supabase/migrations/20260421000000_trade_state_machine_constraints.sql
+++ b/supabase/migrations/20260421000000_trade_state_machine_constraints.sql
@@ -1,0 +1,60 @@
+-- supabase/migrations/20260421000000_trade_state_machine_constraints.sql
+-- ============================================================
+-- NeighborSwap — Trade state machine DB-level enforcement
+--
+-- Adds a BEFORE UPDATE trigger that validates every status change,
+-- mirroring VALID_TRANSITIONS in src/types/trades.ts.
+--
+-- Transition graph (4 user-visible milestones mapped to DB statuses):
+--   INQUIRY phase:  pending_offer ──► negotiating
+--                   pending_offer ──► cancelled
+--                   negotiating   ──► accepted
+--                   negotiating   ──► cancelled
+--   REQUESTED:      accepted      ──► in_progress   (user-initiated)
+--                   accepted      ──► scheduled     (logistics agent)
+--                   accepted      ──► flagged        (safety agent)
+--                   accepted      ──► disputed
+--   PICKED_UP:      scheduled     ──► in_progress
+--   RETURNED:       in_progress   ──► completed
+--                   in_progress   ──► disputed
+--   Terminal:       completed, cancelled, disputed, flagged → ∅
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION validate_trade_transition()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  -- No-op when status is unchanged (e.g. updating logistics_data only)
+  IF OLD.status = NEW.status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Terminal statuses are immutable
+  IF OLD.status IN ('completed', 'cancelled', 'disputed', 'flagged') THEN
+    RAISE EXCEPTION
+      'Trade %: status "%" is terminal and cannot be changed.',
+      OLD.id, OLD.status
+    USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Validate the specific transition
+  IF NOT (
+    (OLD.status = 'pending_offer'  AND NEW.status IN ('negotiating', 'cancelled'))                        OR
+    (OLD.status = 'negotiating'    AND NEW.status IN ('accepted', 'cancelled'))                           OR
+    (OLD.status = 'accepted'       AND NEW.status IN ('in_progress', 'scheduled', 'flagged', 'disputed')) OR
+    (OLD.status = 'scheduled'      AND NEW.status IN ('in_progress'))                                     OR
+    (OLD.status = 'in_progress'    AND NEW.status IN ('completed', 'disputed'))
+  ) THEN
+    RAISE EXCEPTION
+      'Trade %: invalid transition "%" → "%".',
+      OLD.id, OLD.status, NEW.status
+    USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trades_validate_transition
+  BEFORE UPDATE ON trades
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_trade_transition();


### PR DESCRIPTION
## Summary

- **DB trigger**: `validate_trade_transition()` PL/pgSQL function + `trades_validate_transition` BEFORE UPDATE trigger blocks any invalid or terminal-to-anything status transition at the database level as a hard backstop
- **Type-safe transition map**: `VALID_TRANSITIONS` added to `src/types/trades.ts` — the authoritative definition of which status→status moves are allowed and which role (initiator/counterparty) can perform each one, mirroring the `INQUIRY → REQUESTED → PICKED_UP → RETURNED` milestones from the PRD
- **Hardened Server Action**: `updateTradeStatusAction` now fetches the current status, validates the transition path, enforces role-based permissions, and sets lifecycle timestamps (`accepted_at`, `completed_at`, `cancelled_at`) at the appropriate milestones
- **Expanded test suite**: trades test file grows from 7 → 29 tests, covering auth, party check, terminal-status guard, invalid paths, role enforcement, lifecycle timestamps, DB errors, and socket emission

## Migration

The new DB trigger must be applied before enforcement takes effect:

```
supabase/migrations/20260421000000_trade_state_machine_constraints.sql
```

Apply via the Supabase MCP tool or the Supabase dashboard SQL editor.

## Test plan

- [ ] `npm run test` — 164 tests pass (29 in trades suite)
- [ ] `npx tsc --noEmit` — zero type errors
- [ ] `npm run lint` — zero lint errors
- [ ] Manual: as initiator, verify the "Start negotiating" button is hidden on `pending_offer` (counterparty-only) and that calling the action directly returns a role error
- [ ] Manual: follow the full happy path — Pending → Negotiating → Accepted → In Progress → Completed — and confirm `accepted_at` and `completed_at` are populated in the DB after each milestone
- [ ] Manual: attempt a direct skip (e.g., Pending → Completed) and confirm the server returns `"Cannot transition from 'pending_offer' to 'completed'."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)