### PR TITLE
feat(chat): Inquiry-to-Transaction Chat UI with state machine, milestone cards, and reason input

### DIFF
--- a/src/actions/__tests__/trades.test.ts
+++ b/src/actions/__tests__/trades.test.ts
@@ -23,13 +23,16 @@ const mockFetchSelect = vi.fn().mockReturnValue({ eq: mockFetchEq })
 const mockUpdateEq = vi.fn()
 const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq })
 
+// System event messages: from('messages').insert({})
+const mockMessageInsert = vi.fn()
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: { getUser: mockGetUser },
-    from: vi.fn().mockReturnValue({
-      insert: mockInsert,
-      select: mockFetchSelect,
-      update: mockUpdate,
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'messages') return { insert: mockMessageInsert }
+      // 'trades' — exposes all chains; each action uses the right starting method
+      return { insert: mockInsert, select: mockFetchSelect, update: mockUpdate }
     }),
   }),
 }))
@@ -152,6 +155,7 @@ describe('updateTradeStatusAction', () => {
     // Default trade: negotiating (middle of flow, allows many transitions)
     mockFetchSingle.mockResolvedValue({ data: makeTrade('negotiating'), error: null })
     mockUpdateEq.mockResolvedValue({ error: null })
+    mockMessageInsert.mockResolvedValue({ error: null })
   })
 
   // ── Auth ────────────────────────────────────────────────────────────────────
@@ -207,15 +211,14 @@ describe('updateTradeStatusAction', () => {
 
   // ── Role-based permission ───────────────────────────────────────────────────
 
-  it('returns error when initiator tries to start negotiating (counterparty-only)', async () => {
+  it('returns error when initiator tries to start inquiry (counterparty-only)', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
-    // mockGetUser already returns INITIATOR_ID
     const result = await updateTradeStatusAction(TRADE_ID, 'negotiating')
     expect(result.error).toMatch(/counterparty/i)
     expect(mockUpdate).not.toHaveBeenCalled()
   })
 
-  it('allows the counterparty to start negotiating', async () => {
+  it('allows the counterparty to start inquiry', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
     mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
     const result = await updateTradeStatusAction(TRADE_ID, 'negotiating')
@@ -228,25 +231,24 @@ describe('updateTradeStatusAction', () => {
     expect(result.error).toBeNull()
   })
 
-  it('allows the initiator to accept from negotiating', async () => {
-    // mockFetchSingle default is 'negotiating'
+  it('allows the initiator to request swap from negotiating', async () => {
     const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
     expect(result.error).toBeNull()
   })
 
-  it('allows the counterparty to accept from negotiating', async () => {
+  it('allows the counterparty to request swap from negotiating', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
     const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
     expect(result.error).toBeNull()
   })
 
-  it('allows both parties to mark in_progress from accepted', async () => {
+  it('allows both parties to confirm pickup from accepted', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
     const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
     expect(result.error).toBeNull()
   })
 
-  it('allows both parties to mark completed from in_progress', async () => {
+  it('allows both parties to confirm return from in_progress', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
     const result = await updateTradeStatusAction(TRADE_ID, 'completed')
     expect(result.error).toBeNull()
@@ -261,24 +263,21 @@ describe('updateTradeStatusAction', () => {
   // ── Lifecycle timestamps ────────────────────────────────────────────────────
 
   it('sets accepted_at when transitioning to accepted', async () => {
-    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
-    expect(result.error).toBeNull()
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
     const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
     expect(payload.accepted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it('sets completed_at when transitioning to completed', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
-    const result = await updateTradeStatusAction(TRADE_ID, 'completed')
-    expect(result.error).toBeNull()
+    await updateTradeStatusAction(TRADE_ID, 'completed')
     const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
     expect(payload.completed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it('sets cancelled_at when transitioning to cancelled', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
-    const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
-    expect(result.error).toBeNull()
+    await updateTradeStatusAction(TRADE_ID, 'cancelled')
     const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
     expect(payload.cancelled_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
@@ -305,16 +304,13 @@ describe('updateTradeStatusAction', () => {
 
   it('emits the trade status event after a successful update', async () => {
     await updateTradeStatusAction(TRADE_ID, 'accepted')
-    expect(mockEmitToRoom).toHaveBeenCalledOnce()
-    const [room, , payload] = mockEmitToRoom.mock.calls[0] as [
-      string,
-      string,
-      Record<string, unknown>,
-    ]
+    const statusCalls = mockEmitToRoom.mock.calls.filter(([, event]) =>
+      (event as string).startsWith(`trade:${TRADE_ID}:status`)
+    )
+    expect(statusCalls).toHaveLength(1)
+    const [room, , payload] = statusCalls[0] as [string, string, Record<string, unknown>]
     expect(room).toBe(`trade:${TRADE_ID}`)
-    expect(payload.trade_id).toBe(TRADE_ID)
     expect(payload.status).toBe('accepted')
-    expect(payload.updated_at as string).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it('does not emit when DB update fails', async () => {
@@ -323,11 +319,139 @@ describe('updateTradeStatusAction', () => {
     expect(mockEmitToRoom).not.toHaveBeenCalled()
   })
 
-  // ── Update payload ──────────────────────────────────────────────────────────
-
   it('includes the correct status in the DB update payload', async () => {
     await updateTradeStatusAction(TRADE_ID, 'accepted')
     const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
     expect(payload.status).toBe('accepted')
+  })
+
+  // ── System event messages ───────────────────────────────────────────────────
+
+  it('inserts a system event message when transitioning to accepted', async () => {
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(mockMessageInsert).toHaveBeenCalledOnce()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.trade_id).toBe(TRADE_ID)
+    expect(msgPayload.event_type).toBe('status:accepted')
+    expect(typeof msgPayload.content).toBe('string')
+  })
+
+  it('inserts a system event message when confirming pickup (in_progress)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(mockMessageInsert).toHaveBeenCalledOnce()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.event_type).toBe('status:in_progress')
+  })
+
+  it('inserts a system event message when confirming return (completed)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'completed')
+    expect(mockMessageInsert).toHaveBeenCalledOnce()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.event_type).toBe('status:completed')
+  })
+
+  it('inserts a system event message when trade is cancelled', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    expect(mockMessageInsert).toHaveBeenCalledOnce()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.event_type).toBe('status:cancelled')
+  })
+
+  it('inserts a system event message when dispute is raised', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'disputed')
+    expect(mockMessageInsert).toHaveBeenCalledOnce()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.event_type).toBe('status:disputed')
+  })
+
+  it('does not insert a system message for non-milestone transitions (negotiating)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'negotiating')
+    expect(mockMessageInsert).not.toHaveBeenCalled()
+  })
+
+  it('emits a chatMessage socket event for milestone transitions', async () => {
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    const chatCalls = mockEmitToRoom.mock.calls.filter(([, event]) =>
+      (event as string).startsWith(`chat:${TRADE_ID}:message`)
+    )
+    expect(chatCalls).toHaveLength(1)
+    const [, , payload] = chatCalls[0] as [string, string, Record<string, unknown>]
+    expect(payload.event_type).toBe('status:accepted')
+    expect(payload.trade_id).toBe(TRADE_ID)
+  })
+
+  it('does not emit a chatMessage event for non-milestone transitions', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'negotiating')
+    const chatCalls = mockEmitToRoom.mock.calls.filter(([, event]) =>
+      (event as string).startsWith(`chat:${TRADE_ID}:message`)
+    )
+    expect(chatCalls).toHaveLength(0)
+  })
+
+  it('system event message uses the acting user id as sender_id', async () => {
+    await updateTradeStatusAction(TRADE_ID, 'accepted')
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.sender_id).toBe(INITIATOR_ID)
+  })
+
+  // ── Reason field ────────────────────────────────────────────────────────────
+
+  it('stores cancellation_reason in the update payload when reason is provided', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled', 'No longer needed')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.cancellation_reason).toBe('No longer needed')
+  })
+
+  it('does not set cancellation_reason when no reason is provided', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.cancellation_reason).toBeUndefined()
+  })
+
+  it('stores dispute_reason in the update payload when reason is provided', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'disputed', 'Item was damaged')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.dispute_reason).toBe('Item was damaged')
+  })
+
+  it('does not set dispute_reason when no reason is provided', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'disputed')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.dispute_reason).toBeUndefined()
+  })
+
+  it('includes the reason in the system event message content', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled', 'Found another option')
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.content).toContain('Found another option')
+  })
+
+  it('trims whitespace from reason before storing', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled', '  changed my mind  ')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.cancellation_reason).toBe('changed my mind')
+  })
+
+  it('ignores a blank-only reason (treats as no reason)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    await updateTradeStatusAction(TRADE_ID, 'cancelled', '   ')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.cancellation_reason).toBeUndefined()
+    const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(msgPayload.content).toBe('Trade cancelled')
   })
 })

--- a/src/actions/trades.ts
+++ b/src/actions/trades.ts
@@ -53,7 +53,8 @@ export interface UpdateTradeStatusResult {
 
 export async function updateTradeStatusAction(
   tradeId: string,
-  newStatus: TradeStatus
+  newStatus: TradeStatus,
+  reason?: string
 ): Promise<UpdateTradeStatusResult> {
   const supabase = await createClient()
 
@@ -89,12 +90,15 @@ export async function updateTradeStatusAction(
     return { error: `Only the ${transition.roles.join(' or ')} can perform this transition.` }
   }
 
-  // Build update payload; set lifecycle timestamps for key milestones
+  // Build update payload; set lifecycle timestamps and optional reason fields
   const now = new Date().toISOString()
+  const trimmedReason = reason?.trim() || undefined
   const updatePayload: Record<string, unknown> = { status: newStatus }
   if (newStatus === 'accepted') updatePayload.accepted_at = now
   if (newStatus === 'completed') updatePayload.completed_at = now
   if (newStatus === 'cancelled') updatePayload.cancelled_at = now
+  if (newStatus === 'cancelled' && trimmedReason) updatePayload.cancellation_reason = trimmedReason
+  if (newStatus === 'disputed' && trimmedReason) updatePayload.dispute_reason = trimmedReason
 
   const { error } = await supabase.from('trades').update(updatePayload).eq('id', tradeId)
 
@@ -106,5 +110,39 @@ export async function updateTradeStatusAction(
     updated_at: now,
   })
 
+  // Insert a persistent system event message and deliver it to the chat
+  // timeline for possession-transfer milestones and other key transitions.
+  const systemEvent = SYSTEM_EVENTS[newStatus]
+  if (systemEvent) {
+    // Append the user-supplied reason (if any) so it appears in the chat card.
+    const content = trimmedReason ? `${systemEvent.content}: ${trimmedReason}` : systemEvent.content
+
+    await supabase.from('messages').insert({
+      trade_id: tradeId,
+      sender_id: user.id,
+      content,
+      event_type: systemEvent.event_type,
+      sent_at: now,
+    })
+
+    emitToRoom(`trade:${tradeId}`, SOCKET_EVENTS.chatMessage(tradeId), {
+      trade_id: tradeId,
+      sender_id: user.id,
+      content,
+      event_type: systemEvent.event_type,
+      sent_at: now,
+    })
+  }
+
   return { error: null }
+}
+
+// System event messages inserted into the chat when milestone transitions occur.
+// Keyed by the new status.
+const SYSTEM_EVENTS: Partial<Record<TradeStatus, { content: string; event_type: string }>> = {
+  accepted: { content: 'Deal accepted', event_type: 'status:accepted' },
+  in_progress: { content: 'Pickup confirmed', event_type: 'status:in_progress' },
+  completed: { content: 'Return confirmed', event_type: 'status:completed' },
+  cancelled: { content: 'Trade cancelled', event_type: 'status:cancelled' },
+  disputed: { content: 'Dispute raised', event_type: 'status:disputed' },
 }

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,11 +1,29 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { CheckCircle, Package, XCircle, AlertTriangle } from 'lucide-react'
 import type { Message } from '@/types/messages'
 
 interface MessageListProps {
   messages: Message[]
   currentUserId: string
+}
+
+const EVENT_CONFIG: Record<string, { label: string; Icon: React.ElementType; color: string }> = {
+  'status:accepted': { label: 'Deal accepted', Icon: CheckCircle, color: 'text-green-600' },
+  'status:in_progress': { label: 'Pickup confirmed', Icon: Package, color: 'text-purple-600' },
+  'status:completed': { label: 'Return confirmed', Icon: CheckCircle, color: 'text-blue-600' },
+  'status:cancelled': { label: 'Trade cancelled', Icon: XCircle, color: 'text-gray-500' },
+  'status:disputed': { label: 'Dispute raised', Icon: AlertTriangle, color: 'text-orange-600' },
+}
+
+// First-person labels when the current user performed the action.
+const MY_EVENT_LABELS: Record<string, string> = {
+  'status:accepted': 'You accepted the deal',
+  'status:in_progress': 'You confirmed pickup',
+  'status:completed': 'You confirmed return',
+  'status:cancelled': 'You cancelled the trade',
+  'status:disputed': 'You raised a dispute',
 }
 
 export default function MessageList({ messages, currentUserId }: MessageListProps) {
@@ -26,11 +44,41 @@ export default function MessageList({ messages, currentUserId }: MessageListProp
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-3">
       {messages.map((msg) => {
-        const isMine = msg.sender_id === currentUserId
         const time = new Date(msg.sent_at).toLocaleTimeString(undefined, {
           hour: '2-digit',
           minute: '2-digit',
         })
+
+        // System event: render as a centered milestone card
+        if (msg.event_type) {
+          const cfg = EVENT_CONFIG[msg.event_type]
+          const EventIcon = cfg?.Icon ?? CheckCircle
+          const eventColor = cfg?.color ?? 'text-gray-500'
+          const isMyEvent = msg.sender_id === currentUserId
+
+          // When the stored content includes a reason (e.g. "Trade cancelled: reason"),
+          // show it as-is for both parties. Otherwise, use first-person for the sender.
+          const hasReason = cfg != null && msg.content !== cfg.label
+          const displayLabel = hasReason
+            ? msg.content
+            : isMyEvent
+              ? (MY_EVENT_LABELS[msg.event_type] ?? msg.content)
+              : (cfg?.label ?? msg.content)
+
+          return (
+            <div key={msg.id} className="flex justify-center py-1">
+              <div className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-500">
+                <EventIcon className={`h-3 w-3 shrink-0 ${eventColor}`} aria-hidden />
+                <span className="font-medium">{displayLabel}</span>
+                <span aria-hidden>·</span>
+                <time dateTime={msg.sent_at}>{time}</time>
+              </div>
+            </div>
+          )
+        }
+
+        // Regular chat bubble
+        const isMine = msg.sender_id === currentUserId
         return (
           <div key={msg.id} className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
             <div

--- a/src/components/chat/TradeStatusPanel.tsx
+++ b/src/components/chat/TradeStatusPanel.tsx
@@ -20,57 +20,115 @@ interface Transition {
   forInitiator: boolean
   forCounterparty: boolean
   danger: boolean
+  requiresConfirmation: boolean
+  requiresReason: boolean // shows a reason textarea before confirming
+}
+
+// Text shown in the inline confirmation prompt before executing a
+// possession-transfer transition.
+const CONFIRMATION_PROMPTS: Partial<Record<TradeStatus, string>> = {
+  in_progress:
+    'This records that the item has been picked up and you are now responsible for its safe return.',
+  completed: 'This records that the item has been returned to the provider.',
+}
+
+// Placeholder text for the reason textarea shown on cancel / dispute flows.
+const REASON_PLACEHOLDERS: Partial<Record<TradeStatus, string>> = {
+  cancelled: 'Why are you cancelling? (optional)',
+  disputed: 'Describe the issue… (optional)',
 }
 
 const TRANSITIONS: Partial<Record<TradeStatus, Transition[]>> = {
   pending_offer: [
     {
       next: 'negotiating',
-      label: 'Start negotiating',
+      label: 'Start Inquiry',
       forInitiator: false,
       forCounterparty: true,
       danger: false,
+      requiresConfirmation: false,
+      requiresReason: false,
     },
-    { next: 'cancelled', label: 'Cancel', forInitiator: true, forCounterparty: true, danger: true },
+    {
+      next: 'cancelled',
+      label: 'Cancel',
+      forInitiator: true,
+      forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
+    },
   ],
   negotiating: [
     {
       next: 'accepted',
-      label: 'Accept deal',
+      label: 'Request Swap',
       forInitiator: true,
       forCounterparty: true,
       danger: false,
+      requiresConfirmation: false,
+      requiresReason: false,
     },
-    { next: 'cancelled', label: 'Cancel', forInitiator: true, forCounterparty: true, danger: true },
+    {
+      next: 'cancelled',
+      label: 'Cancel',
+      forInitiator: true,
+      forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
+    },
   ],
   accepted: [
     {
       next: 'in_progress',
-      label: 'Mark in progress',
+      label: 'Confirm Pickup',
       forInitiator: true,
       forCounterparty: true,
       danger: false,
+      requiresConfirmation: true,
+      requiresReason: false,
     },
-    { next: 'disputed', label: 'Dispute', forInitiator: true, forCounterparty: true, danger: true },
+    {
+      next: 'disputed',
+      label: 'Dispute',
+      forInitiator: true,
+      forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
+    },
   ],
   scheduled: [
     {
       next: 'in_progress',
-      label: 'Mark in progress',
+      label: 'Confirm Pickup',
       forInitiator: true,
       forCounterparty: true,
       danger: false,
+      requiresConfirmation: true,
+      requiresReason: false,
     },
   ],
   in_progress: [
     {
       next: 'completed',
-      label: 'Mark completed',
+      label: 'Confirm Return',
       forInitiator: true,
       forCounterparty: true,
       danger: false,
+      requiresConfirmation: true,
+      requiresReason: false,
     },
-    { next: 'disputed', label: 'Dispute', forInitiator: true, forCounterparty: true, danger: true },
+    {
+      next: 'disputed',
+      label: 'Dispute',
+      forInitiator: true,
+      forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
+    },
   ],
 }
 
@@ -145,6 +203,8 @@ export default function TradeStatusPanel({
   const status = useTrade(tradeId, initialStatus)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+  const [confirmingNext, setConfirmingNext] = useState<TradeStatus | null>(null)
+  const [reasonText, setReasonText] = useState('')
 
   const isInitiator = currentUserId === initiatorId
   const isCounterparty = currentUserId === counterpartyId
@@ -153,48 +213,135 @@ export default function TradeStatusPanel({
 
   const availableTransitions = getAvailableTransitions(status, isInitiator, isCounterparty)
 
-  function handleTransition(next: TradeStatus) {
+  const confirmingTransition = availableTransitions.find((t) => t.next === confirmingNext)
+  const confirmingNeedsReason = confirmingTransition?.requiresReason ?? false
+
+  function handleTransitionClick(t: Transition) {
     setError(null)
+    if (t.requiresConfirmation || t.requiresReason) {
+      setConfirmingNext(t.next)
+    } else {
+      executeTransition(t.next)
+    }
+  }
+
+  function handleConfirm() {
+    if (confirmingNext) {
+      executeTransition(confirmingNext, confirmingNeedsReason ? reasonText : undefined)
+    }
+  }
+
+  function handleCancelConfirm() {
+    setConfirmingNext(null)
+    setReasonText('')
+  }
+
+  function executeTransition(next: TradeStatus, reason?: string) {
+    setConfirmingNext(null)
+    setReasonText('')
     startTransition(async () => {
-      const result = await updateTradeStatusAction(tradeId, next)
+      const result = await updateTradeStatusAction(tradeId, next, reason?.trim() || undefined)
       if (result.error) setError(result.error)
     })
   }
 
   return (
-    <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50 px-4 py-2">
-      <span
-        className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${color}`}
-      >
-        <Icon className="h-3 w-3" aria-hidden />
-        {label}
-      </span>
+    <div className="border-b border-gray-100 bg-gray-50 px-4 py-2">
+      <div className="flex items-center gap-3">
+        {/* Status badge */}
+        <span
+          className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${color}`}
+        >
+          <Icon className="h-3 w-3" aria-hidden />
+          {label}
+        </span>
 
-      {availableTransitions.length > 0 && (
-        <div className="flex items-center gap-2">
-          {availableTransitions.map((t) => (
-            <button
-              key={t.next}
-              onClick={() => handleTransition(t.next)}
-              disabled={isPending}
-              className={`inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                t.danger
-                  ? 'border-red-200 text-red-600 hover:bg-red-50'
-                  : 'border-green-200 text-green-700 hover:bg-green-50'
-              }`}
-            >
-              {isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden />}
-              {t.label}
-            </button>
-          ))}
-        </div>
-      )}
+        {/* Inline confirmation prompt or action buttons */}
+        {confirmingNext ? (
+          <div className="min-w-0 flex-1">
+            {confirmingNeedsReason ? (
+              // Reason-input flow: stacked layout with optional textarea
+              <div className="flex flex-col gap-1.5">
+                <textarea
+                  value={reasonText}
+                  onChange={(e) => setReasonText(e.target.value)}
+                  placeholder={REASON_PLACEHOLDERS[confirmingNext] ?? 'Add a reason (optional)…'}
+                  disabled={isPending}
+                  rows={2}
+                  className="w-full resize-none rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs text-gray-700 placeholder-gray-400 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 disabled:opacity-50"
+                />
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={handleConfirm}
+                    disabled={isPending}
+                    className="inline-flex items-center gap-1 rounded-lg border border-red-200 bg-red-50 px-2.5 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden />}
+                    Confirm
+                  </button>
+                  <button
+                    onClick={handleCancelConfirm}
+                    disabled={isPending}
+                    className="rounded-lg border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 disabled:opacity-50"
+                  >
+                    Back
+                  </button>
+                </div>
+              </div>
+            ) : (
+              // Possession-confirmation flow: single-line prompt with confirm/back
+              <div className="flex items-center gap-2">
+                <p className="min-w-0 truncate text-xs text-gray-600">
+                  {CONFIRMATION_PROMPTS[confirmingNext] ?? 'Are you sure?'}
+                </p>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <button
+                    onClick={handleConfirm}
+                    disabled={isPending}
+                    className="inline-flex items-center gap-1 rounded-lg border border-green-300 bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 transition-colors hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden />}
+                    Confirm
+                  </button>
+                  <button
+                    onClick={handleCancelConfirm}
+                    disabled={isPending}
+                    className="rounded-lg border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 disabled:opacity-50"
+                  >
+                    Back
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          availableTransitions.length > 0 && (
+            <div className="flex items-center gap-2">
+              {availableTransitions.map((t) => (
+                <button
+                  key={t.next}
+                  onClick={() => handleTransitionClick(t)}
+                  disabled={isPending}
+                  className={`inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                    t.danger
+                      ? 'border-red-200 text-red-600 hover:bg-red-50'
+                      : 'border-green-200 text-green-700 hover:bg-green-50'
+                  }`}
+                >
+                  {isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden />}
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          )
+        )}
 
-      {error && (
-        <p className="ml-auto text-xs text-red-600" role="alert">
-          {error}
-        </p>
-      )}
+        {error && (
+          <p className="ml-auto shrink-0 text-xs text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/chat/__tests__/TradeStatusPanel.test.ts
+++ b/src/components/chat/__tests__/TradeStatusPanel.test.ts
@@ -8,67 +8,172 @@ import { getAvailableTransitions } from '../TradeStatusPanel'
 describe('getAvailableTransitions', () => {
   // ── pending_offer ──────────────────────────────────────────────────────────
 
-  it('pending_offer: counterparty can start negotiating or cancel', () => {
-    const transitions = getAvailableTransitions('pending_offer', false, true)
-    const nexts = transitions.map((t) => t.next)
+  it('pending_offer: counterparty can start inquiry or cancel', () => {
+    const nexts = getAvailableTransitions('pending_offer', false, true).map((t) => t.next)
     expect(nexts).toContain('negotiating')
     expect(nexts).toContain('cancelled')
   })
 
-  it('pending_offer: initiator can only cancel (not start negotiating)', () => {
-    const transitions = getAvailableTransitions('pending_offer', true, false)
-    const nexts = transitions.map((t) => t.next)
+  it('pending_offer: initiator can only cancel (not start inquiry)', () => {
+    const nexts = getAvailableTransitions('pending_offer', true, false).map((t) => t.next)
     expect(nexts).not.toContain('negotiating')
     expect(nexts).toContain('cancelled')
   })
 
-  it('pending_offer: negotiating transition is not flagged as danger', () => {
-    const transitions = getAvailableTransitions('pending_offer', false, true)
-    const negotiate = transitions.find((t) => t.next === 'negotiating')
-    expect(negotiate?.danger).toBe(false)
+  it('pending_offer: start inquiry button is labeled "Start Inquiry"', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'negotiating'
+    )
+    expect(t?.label).toBe('Start Inquiry')
   })
 
-  it('pending_offer: cancel transition is flagged as danger', () => {
-    const transitions = getAvailableTransitions('pending_offer', false, true)
-    const cancel = transitions.find((t) => t.next === 'cancelled')
-    expect(cancel?.danger).toBe(true)
+  it('pending_offer: start inquiry is not a danger action', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'negotiating'
+    )
+    expect(t?.danger).toBe(false)
+  })
+
+  it('pending_offer: start inquiry does not require confirmation', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'negotiating'
+    )
+    expect(t?.requiresConfirmation).toBe(false)
+  })
+
+  it('pending_offer: cancel is a danger action', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'cancelled'
+    )
+    expect(t?.danger).toBe(true)
+  })
+
+  it('pending_offer: cancel requires confirmation and a reason', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'cancelled'
+    )
+    expect(t?.requiresConfirmation).toBe(true)
+    expect(t?.requiresReason).toBe(true)
   })
 
   // ── negotiating ────────────────────────────────────────────────────────────
 
-  it('negotiating: both parties can accept or cancel', () => {
-    const asInitiator = getAvailableTransitions('negotiating', true, false)
-    const asCounterparty = getAvailableTransitions('negotiating', false, true)
-    expect(asInitiator.map((t) => t.next)).toContain('accepted')
-    expect(asCounterparty.map((t) => t.next)).toContain('accepted')
-    expect(asInitiator.map((t) => t.next)).toContain('cancelled')
-    expect(asCounterparty.map((t) => t.next)).toContain('cancelled')
+  it('negotiating: both parties can request swap or cancel', () => {
+    const asInitiator = getAvailableTransitions('negotiating', true, false).map((t) => t.next)
+    const asCounterparty = getAvailableTransitions('negotiating', false, true).map((t) => t.next)
+    expect(asInitiator).toContain('accepted')
+    expect(asCounterparty).toContain('accepted')
+    expect(asInitiator).toContain('cancelled')
+    expect(asCounterparty).toContain('cancelled')
+  })
+
+  it('negotiating: request swap button is labeled "Request Swap"', () => {
+    const t = getAvailableTransitions('negotiating', true, false).find((x) => x.next === 'accepted')
+    expect(t?.label).toBe('Request Swap')
+  })
+
+  it('negotiating: request swap does not require confirmation', () => {
+    const t = getAvailableTransitions('negotiating', true, false).find((x) => x.next === 'accepted')
+    expect(t?.requiresConfirmation).toBe(false)
   })
 
   // ── accepted ───────────────────────────────────────────────────────────────
 
-  it('accepted: both parties can mark in_progress or dispute', () => {
-    const transitions = getAvailableTransitions('accepted', true, false)
-    const nexts = transitions.map((t) => t.next)
+  it('accepted: both parties can confirm pickup or dispute', () => {
+    const nexts = getAvailableTransitions('accepted', true, false).map((t) => t.next)
     expect(nexts).toContain('in_progress')
     expect(nexts).toContain('disputed')
   })
 
+  it('accepted: confirm pickup button is labeled "Confirm Pickup"', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'in_progress')
+    expect(t?.label).toBe('Confirm Pickup')
+  })
+
+  it('accepted: confirm pickup requires confirmation (possession transfer)', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'in_progress')
+    expect(t?.requiresConfirmation).toBe(true)
+  })
+
+  it('accepted: confirm pickup is not a danger action', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'in_progress')
+    expect(t?.danger).toBe(false)
+  })
+
+  it('accepted: dispute is a danger action that requires confirmation and a reason', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'disputed')
+    expect(t?.danger).toBe(true)
+    expect(t?.requiresConfirmation).toBe(true)
+    expect(t?.requiresReason).toBe(true)
+  })
+
+  it('accepted: confirm pickup does not require a reason', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'in_progress')
+    expect(t?.requiresReason).toBe(false)
+  })
+
+  // ── scheduled ─────────────────────────────────────────────────────────────
+
+  it('scheduled: both parties can confirm pickup', () => {
+    const nexts = getAvailableTransitions('scheduled', true, false).map((t) => t.next)
+    expect(nexts).toContain('in_progress')
+  })
+
+  it('scheduled: confirm pickup requires confirmation', () => {
+    const t = getAvailableTransitions('scheduled', true, false).find(
+      (x) => x.next === 'in_progress'
+    )
+    expect(t?.requiresConfirmation).toBe(true)
+  })
+
   // ── in_progress ────────────────────────────────────────────────────────────
 
-  it('in_progress: both parties can complete or dispute', () => {
-    const transitions = getAvailableTransitions('in_progress', true, false)
-    const nexts = transitions.map((t) => t.next)
+  it('in_progress: both parties can confirm return or dispute', () => {
+    const nexts = getAvailableTransitions('in_progress', true, false).map((t) => t.next)
     expect(nexts).toContain('completed')
     expect(nexts).toContain('disputed')
   })
 
-  it('in_progress: complete is not danger, dispute is danger', () => {
-    const transitions = getAvailableTransitions('in_progress', true, false)
-    const complete = transitions.find((t) => t.next === 'completed')
-    const dispute = transitions.find((t) => t.next === 'disputed')
-    expect(complete?.danger).toBe(false)
-    expect(dispute?.danger).toBe(true)
+  it('in_progress: confirm return button is labeled "Confirm Return"', () => {
+    const t = getAvailableTransitions('in_progress', true, false).find(
+      (x) => x.next === 'completed'
+    )
+    expect(t?.label).toBe('Confirm Return')
+  })
+
+  it('in_progress: confirm return requires confirmation (possession transfer)', () => {
+    const t = getAvailableTransitions('in_progress', true, false).find(
+      (x) => x.next === 'completed'
+    )
+    expect(t?.requiresConfirmation).toBe(true)
+  })
+
+  it('in_progress: confirm return is not a danger action', () => {
+    const t = getAvailableTransitions('in_progress', true, false).find(
+      (x) => x.next === 'completed'
+    )
+    expect(t?.danger).toBe(false)
+  })
+
+  it('in_progress: confirm return does not require a reason', () => {
+    const t = getAvailableTransitions('in_progress', true, false).find(
+      (x) => x.next === 'completed'
+    )
+    expect(t?.requiresReason).toBe(false)
+  })
+
+  it('in_progress: dispute requires confirmation and a reason', () => {
+    const t = getAvailableTransitions('in_progress', true, false).find((x) => x.next === 'disputed')
+    expect(t?.requiresConfirmation).toBe(true)
+    expect(t?.requiresReason).toBe(true)
+  })
+
+  it('negotiating: cancel requires confirmation and a reason', () => {
+    const t = getAvailableTransitions('negotiating', true, false).find(
+      (x) => x.next === 'cancelled'
+    )
+    expect(t?.requiresConfirmation).toBe(true)
+    expect(t?.requiresReason).toBe(true)
   })
 
   // ── terminal statuses ──────────────────────────────────────────────────────

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -34,6 +34,7 @@ export function useChat(tradeId: string, initialMessages: Message[] = []): Messa
             trade_id: payload.trade_id,
             sender_id: payload.sender_id,
             content: payload.content,
+            event_type: payload.event_type ?? null,
             sent_at: payload.sent_at,
             created_at: payload.sent_at,
           },

--- a/src/lib/socket/index.ts
+++ b/src/lib/socket/index.ts
@@ -36,6 +36,7 @@ export interface ChatMessagePayload {
   trade_id: string
   sender_id: string
   content: string
+  event_type?: string // present only for system event messages
   sent_at: string // ISO-8601
 }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -6,6 +6,7 @@ export interface Message {
   trade_id: string
   sender_id: string
   content: string
+  event_type: string | null // null = regular chat message; 'status:<state>' = system event
   sent_at: string // ISO-8601
   created_at: string // ISO-8601
 }

--- a/supabase/migrations/20260421000001_messages_add_event_type.sql
+++ b/supabase/migrations/20260421000001_messages_add_event_type.sql
@@ -1,0 +1,20 @@
+-- supabase/migrations/20260421000001_messages_add_event_type.sql
+-- ============================================================
+-- NeighborSwap — Add event_type to messages
+--
+-- Allows system-generated event messages to coexist with user chat
+-- messages in the same table. NULL = regular chat message.
+-- Non-null values use the format 'status:<new_status>', e.g.:
+--   status:accepted, status:in_progress, status:completed,
+--   status:cancelled, status:disputed
+--
+-- System event messages are inserted by updateTradeStatusAction
+-- (src/actions/trades.ts) to provide a persistent in-chat record
+-- of possession-transfer milestones.
+-- ============================================================
+
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS event_type TEXT;
+
+COMMENT ON COLUMN messages.event_type IS
+  'System event type (e.g. status:in_progress). NULL for regular user chat messages.';


### PR DESCRIPTION
## Summary

- **State machine enforcement** (`5852c82`): DB-level trigger + server-side validation prevent invalid trade status transitions (`pending_offer → negotiating → accepted → in_progress → completed`); role-based permission checks (e.g. only the counterparty can start an inquiry); lifecycle timestamps (`accepted_at`, `completed_at`, `cancelled_at`) are written on milestone transitions
- **Interactive status buttons** (`c7781f1` + `5852c82`): `TradeStatusPanel` shows contextual action buttons (Start Inquiry, Request Swap, Confirm Pickup, Confirm Return, Cancel, Dispute) filtered by current status and the acting user's role; possession-transfer transitions show an inline confirmation step
- **System event cards in chat** (`d1dbdf3`): milestone transitions insert a persistent message into the chat timeline rendered as a centred pill card (Deal accepted, Pickup confirmed, Return confirmed, Trade cancelled, Dispute raised)
- **First-person attribution** (`d1dbdf3`): the acting user sees "You confirmed pickup" while the other party sees "Pickup confirmed"; when a reason is provided it is appended to the content for both parties
- **Reason input for cancel/dispute** (`d1dbdf3`): an optional textarea appears before executing Cancel or Dispute transitions; the reason is stored in `cancellation_reason` / `dispute_reason` and embedded in the system event message

## DB migrations to apply

Both files are in `supabase/migrations/` and must be applied via the Supabase dashboard or MCP before deploying:

1. `20260421000000_trade_state_machine_constraints.sql` — transition-guard trigger
2. `20260421000001_messages_add_event_type.sql` — `event_type` column on `messages`

## Test plan

- [ ] Open a trade chat as the counterparty — "Start Inquiry" button appears; initiator sees only "Cancel"
- [ ] Click Start Inquiry — status badge changes to "Negotiating"; "Deal accepted" pill does NOT appear (no system event for this transition)
- [ ] Click Request Swap as either party — status changes to "Accepted"; "Deal accepted" pill appears in chat
- [ ] Click Confirm Pickup — inline confirmation prompt appears; confirm → "Pickup confirmed" pill appears
- [ ] Click Cancel from any eligible state — reason textarea appears; submit with/without a reason → "Trade cancelled: <reason>" or "Trade cancelled" pill
- [ ] Verify terminal states (completed, cancelled, disputed) show no action buttons
- [ ] Run `npm run test` — 197 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)