### PR TITLE
feat(chat): Inquiry-to-Transaction Chat UI with trade state machine

### DIFF
--- a/src/actions/__tests__/trades.test.ts
+++ b/src/actions/__tests__/trades.test.ts
@@ -14,10 +14,22 @@ const mockInsertSingle = vi.fn()
 const mockInsertSelect = vi.fn().mockReturnValue({ single: mockInsertSingle })
 const mockInsert = vi.fn().mockReturnValue({ select: mockInsertSelect })
 
-// updateTradeStatusAction — fetch: from('trades').select('...').eq().single()
+// updateTradeStatusAction — fetch: from('trades').select('status,...').eq().single()
 const mockFetchSingle = vi.fn()
 const mockFetchEq = vi.fn().mockReturnValue({ single: mockFetchSingle })
-const mockFetchSelect = vi.fn().mockReturnValue({ eq: mockFetchEq })
+
+// updateTradeStatusAction — conflict check: select('id').eq().neq().in().limit().maybeSingle()
+const mockConflictMaybeSingle = vi.fn()
+const mockConflictLimit = vi.fn().mockReturnValue({ maybeSingle: mockConflictMaybeSingle })
+const mockConflictIn = vi.fn().mockReturnValue({ limit: mockConflictLimit })
+const mockConflictNeq = vi.fn().mockReturnValue({ in: mockConflictIn })
+const mockConflictEq = vi.fn().mockReturnValue({ neq: mockConflictNeq })
+
+// Differentiate chains by column argument: 'id' → conflict check, anything else → fetch
+const mockFetchSelect = vi.fn().mockImplementation((columns: string) => {
+  if (columns === 'id') return { eq: mockConflictEq }
+  return { eq: mockFetchEq }
+})
 
 // updateTradeStatusAction — update: from('trades').update({}).eq()
 const mockUpdateEq = vi.fn()
@@ -63,9 +75,10 @@ const NEW_TRADE_ID = 'trade-new-1'
 const TRADE_ID = 'trade-uuid-001'
 const INITIATOR_ID = 'user-initiator-001'
 const COUNTERPARTY_ID = 'user-counterparty-001'
+const ITEM_ID = 'item-test-001'
 
 function makeTrade(status = 'pending_offer') {
-  return { status, initiator_id: INITIATOR_ID, counterparty_id: COUNTERPARTY_ID }
+  return { status, initiator_id: INITIATOR_ID, counterparty_id: COUNTERPARTY_ID, item_id: ITEM_ID }
 }
 
 // ── createTradeAction ─────────────────────────────────────────────────────────
@@ -156,6 +169,8 @@ describe('updateTradeStatusAction', () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('negotiating'), error: null })
     mockUpdateEq.mockResolvedValue({ error: null })
     mockMessageInsert.mockResolvedValue({ error: null })
+    // Default: no competing active trade (conflict check returns null)
+    mockConflictMaybeSingle.mockResolvedValue({ data: null, error: null })
   })
 
   // ── Auth ────────────────────────────────────────────────────────────────────
@@ -304,6 +319,28 @@ describe('updateTradeStatusAction', () => {
     expect(payload.accepted_at).toBeUndefined()
     expect(payload.completed_at).toBeUndefined()
     expect(payload.cancelled_at).toBeUndefined()
+  })
+
+  // ── Duplicate active trade (conflict check) ─────────────────────────────────
+
+  it('returns clear error when pre-flight conflict check finds an active trade', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    mockConflictMaybeSingle.mockResolvedValue({ data: { id: 'other-trade-999' }, error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(result.error).toMatch(/already part of an active trade/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns clear error for 23505 unique violation (race condition bypasses pre-flight)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    // Pre-flight sees no conflict (race: another request wins between check and update)
+    mockConflictMaybeSingle.mockResolvedValue({ data: null, error: null })
+    mockUpdateEq.mockResolvedValue({
+      error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    })
+    const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(result.error).toMatch(/already part of an active trade/i)
+    expect(mockEmitToRoom).not.toHaveBeenCalled()
   })
 
   // ── DB failure ──────────────────────────────────────────────────────────────

--- a/src/actions/trades.ts
+++ b/src/actions/trades.ts
@@ -65,7 +65,7 @@ export async function updateTradeStatusAction(
 
   const { data: trade } = await supabase
     .from('trades')
-    .select('status, initiator_id, counterparty_id')
+    .select('status, initiator_id, counterparty_id, item_id')
     .eq('id', tradeId)
     .single()
 
@@ -90,6 +90,27 @@ export async function updateTradeStatusAction(
     return { error: `Only the ${transition.roles.join(' or ')} can perform this transition.` }
   }
 
+  // Guard: when confirming pickup, ensure no other trade for this item is
+  // already active (in_progress or completed).  The DB enforces this via a
+  // partial unique index; checking here first gives a clear error message.
+  if (newStatus === 'in_progress') {
+    const { data: conflict } = await supabase
+      .from('trades')
+      .select('id')
+      .eq('item_id', trade.item_id)
+      .neq('id', tradeId)
+      .in('status', ['in_progress', 'completed'])
+      .limit(1)
+      .maybeSingle()
+
+    if (conflict) {
+      return {
+        error:
+          'This item is already part of an active trade. The previous trade must be completed or cancelled before confirming pickup.',
+      }
+    }
+  }
+
   // Build update payload; set lifecycle timestamps and optional reason fields
   const now = new Date().toISOString()
   const trimmedReason = reason?.trim() || undefined
@@ -111,6 +132,14 @@ export async function updateTradeStatusAction(
       details: error.details,
       hint: error.hint,
     })
+    // 23505 = unique_violation — another trade for the same item is already
+    // in_progress or completed (idx_trades_item_one_active partial unique index).
+    if (error.code === '23505') {
+      return {
+        error:
+          'This item is already part of an active trade. The previous trade must be completed or cancelled first.',
+      }
+    }
     return { error: `Failed to update trade status: ${error.message}` }
   }
 


### PR DESCRIPTION
## Summary

- **Chat UI**: Full real-time chat window per trade with Socket.io message delivery and server-rendered initial messages
- **Trade state machine**: 8-state lifecycle (`pending_offer → negotiating → accepted → scheduled → in_progress → completed / cancelled / disputed`) enforced at DB, server action, and UI layers
- **Role-enforced actions**: Confirm Pickup is initiator (borrower) only; Confirm Return is counterparty (lender) only — enforced in both `VALID_TRANSITIONS` and `TradeStatusPanel`
- **System event messages**: Milestone transitions (accepted, pickup confirmed, return confirmed, cancelled, disputed) insert a persistent chat card and emit a Socket.io event
- **Duplicate active trade protection**: Pre-flight conflict check + `23505` unique-violation handler with clear user-facing message, backed by `idx_trades_item_one_active` partial unique index
- **CI fix**: Preview deploy workflow now syncs Supabase env vars to Vercel preview environment (was causing 500 "URL and Key are required" on all preview builds)
- **Error boundary**: `chat/error.tsx` catches server component errors and surfaces the actual message instead of a generic crash screen

## Key files

| Layer | File |
|---|---|
| Server Action | `src/actions/trades.ts` |
| Types / state machine | `src/types/trades.ts` |
| Chat page | `src/app/(main)/chat/[tradeId]/page.tsx` |
| Status panel | `src/components/chat/TradeStatusPanel.tsx` |
| Error boundary | `src/app/(main)/chat/error.tsx` |
| CI | `.github/workflows/preview-deploy.yml` |

## Test plan

- [ ] As borrower: open a trade in `accepted` state → only "Confirm Pickup" button visible
- [ ] As lender: open same trade → no "Confirm Pickup" button; "Confirm Return" visible after pickup confirmed
- [ ] As borrower: click "Confirm Pickup" on an item that already has an active trade → friendly error message (no crash)
- [ ] Send a chat message → appears in real time for both parties
- [ ] Accept / cancel / dispute a trade → system event card appears in chat timeline
- [ ] Open `/chat` with no active trades → sidebar renders empty state without crashing

## DB migrations (must be applied)

```
supabase/migrations/20260421000000_trade_state_machine_constraints.sql
supabase/migrations/20260421000001_messages_add_event_type.sql
```

Apply via Supabase dashboard or `supabase db push`.

## Test results

```
Test Files  10 passed (10)
     Tests  206 passed (206)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)