### PR TITLE
feat(trades): contract locking — freeze agreed_terms at acceptance

### DIFF
--- a/src/actions/__tests__/trades.test.ts
+++ b/src/actions/__tests__/trades.test.ts
@@ -53,7 +53,8 @@ vi.mock('@/lib/socket/emitter', () => ({ emitToRoom: mockEmitToRoom }))
 vi.mock('next/navigation', () => ({ redirect: mockRedirect }))
 
 // Lazy import AFTER mocks are hoisted
-const { createTradeAction, updateTradeStatusAction } = await import('../trades')
+const { createTradeAction, updateTradeStatusAction, updateAgreedTermsAction } =
+  await import('../trades')
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -506,5 +507,140 @@ describe('updateTradeStatusAction', () => {
     expect(payload.cancellation_reason).toBeUndefined()
     const msgPayload = mockMessageInsert.mock.calls[0][0] as Record<string, unknown>
     expect(msgPayload.content).toBe('Trade cancelled')
+  })
+})
+
+// ── updateAgreedTermsAction ───────────────────────────────────────────────────
+
+describe('updateAgreedTermsAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetUser.mockResolvedValue({ data: { user: { id: INITIATOR_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('negotiating'), error: null })
+    mockUpdateEq.mockResolvedValue({ error: null })
+  })
+
+  // ── Auth ────────────────────────────────────────────────────────────────────
+
+  it('returns error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toMatch(/not authenticated/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  it('returns error when terms is empty string', async () => {
+    const result = await updateAgreedTermsAction(TRADE_ID, '')
+    expect(result.error).toMatch(/cannot be empty/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns error when terms is whitespace-only', async () => {
+    const result = await updateAgreedTermsAction(TRADE_ID, '   ')
+    expect(result.error).toMatch(/cannot be empty/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Trade lookup ────────────────────────────────────────────────────────────
+
+  it('returns error when trade is not found', async () => {
+    mockFetchSingle.mockResolvedValue({ data: null, error: { message: 'not found' } })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toMatch(/trade not found/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns error when user is not a party to the trade', async () => {
+    mockFetchSingle.mockResolvedValue({
+      data: { status: 'negotiating', initiator_id: 'other-1', counterparty_id: 'other-2' },
+      error: null,
+    })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toMatch(/not authorized/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Contract lock enforcement ───────────────────────────────────────────────
+
+  it('returns lock error when trade is accepted (contract locked)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Different terms')
+    expect(result.error).toMatch(/locked/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns lock error when trade is in_progress', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('in_progress'), error: null })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Different terms')
+    expect(result.error).toMatch(/locked/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns lock error when trade is completed (terminal)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('completed'), error: null })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Different terms')
+    expect(result.error).toMatch(/locked/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns lock error when trade is cancelled (terminal)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('cancelled'), error: null })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Different terms')
+    expect(result.error).toMatch(/locked/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  // ── Mutable phases ──────────────────────────────────────────────────────────
+
+  it('allows terms update during negotiating phase', async () => {
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toBeNull()
+    expect(mockUpdate).toHaveBeenCalledOnce()
+  })
+
+  it('allows terms update during pending_offer phase', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toBeNull()
+    expect(mockUpdate).toHaveBeenCalledOnce()
+  })
+
+  it('allows counterparty to update terms during negotiating', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Revised terms from counterparty')
+    expect(result.error).toBeNull()
+  })
+
+  // ── DB payload ──────────────────────────────────────────────────────────────
+
+  it('writes trimmed terms to the DB update payload', async () => {
+    await updateAgreedTermsAction(TRADE_ID, '  Borrow drill for 2 days  ')
+    const payload = mockUpdate.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.agreed_terms).toBe('Borrow drill for 2 days')
+  })
+
+  it('scopes the update to the correct trade row', async () => {
+    await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(mockUpdateEq).toHaveBeenCalledWith('id', TRADE_ID)
+  })
+
+  // ── DB-level check_violation (trigger fires) ────────────────────────────────
+
+  it('maps 23514 check_violation to the locked error message', async () => {
+    mockUpdateEq.mockResolvedValue({
+      error: { code: '23514', message: 'agreed_terms is locked once the contract is accepted' },
+    })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toMatch(/locked/i)
+  })
+
+  // ── Generic DB failure ──────────────────────────────────────────────────────
+
+  it('returns generic error when DB fails for other reasons', async () => {
+    mockUpdateEq.mockResolvedValue({ error: { code: '42501', message: 'permission denied' } })
+    const result = await updateAgreedTermsAction(TRADE_ID, 'Borrow drill for 2 days')
+    expect(result.error).toMatch(/failed to update agreed terms/i)
   })
 })

--- a/src/actions/trades.ts
+++ b/src/actions/trades.ts
@@ -184,6 +184,61 @@ export async function updateTradeStatusAction(
   return { error: null }
 }
 
+export interface UpdateAgreedTermsResult {
+  error: string | null
+}
+
+/**
+ * Updates agreed_terms during the negotiation phase. Once a trade reaches
+ * 'accepted' the contract is locked and this action returns an error.
+ * The DB trigger trades_lock_agreed_terms provides a second enforcement layer.
+ */
+export async function updateAgreedTermsAction(
+  tradeId: string,
+  terms: string
+): Promise<UpdateAgreedTermsResult> {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated.' }
+
+  const trimmedTerms = terms.trim()
+  if (!trimmedTerms) return { error: 'Agreed terms cannot be empty.' }
+
+  const { data: trade } = await supabase
+    .from('trades')
+    .select('status, initiator_id, counterparty_id')
+    .eq('id', tradeId)
+    .single()
+
+  if (!trade) return { error: 'Trade not found.' }
+
+  const isParty = trade.initiator_id === user.id || trade.counterparty_id === user.id
+  if (!isParty) return { error: 'Not authorized.' }
+
+  const currentStatus = trade.status as TradeStatus
+  if (currentStatus !== 'pending_offer' && currentStatus !== 'negotiating') {
+    return { error: 'Agreed terms are locked once the contract is accepted.' }
+  }
+
+  const { error } = await supabase
+    .from('trades')
+    .update({ agreed_terms: trimmedTerms })
+    .eq('id', tradeId)
+
+  if (error) {
+    // 23514 = check_violation — DB trigger fires if status check was bypassed.
+    if (error.code === '23514') {
+      return { error: 'Agreed terms are locked once the contract is accepted.' }
+    }
+    return { error: `Failed to update agreed terms: ${error.message}` }
+  }
+
+  return { error: null }
+}
+
 // System event messages inserted into the chat when milestone transitions occur.
 // Keyed by the new status.
 const SYSTEM_EVENTS: Partial<Record<TradeStatus, { content: string; event_type: string }>> = {

--- a/supabase/migrations/20260421000002_contract_locking.sql
+++ b/supabase/migrations/20260421000002_contract_locking.sql
@@ -1,0 +1,40 @@
+-- supabase/migrations/20260421000002_contract_locking.sql
+-- ============================================================
+-- NeighborSwap — Contract locking for agreed_terms
+--
+-- The "digital contract" is locked when a trade transitions to
+-- 'accepted' (i.e. when either party clicks "Request Swap").
+-- After that point, agreed_terms must not change — any UPDATE
+-- that attempts to modify the column while the trade is past the
+-- negotiation phase is rejected at the DB layer.
+--
+-- This is a defense-in-depth layer below the application-level
+-- guard in updateAgreedTermsAction (src/actions/trades.ts).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION prevent_agreed_terms_modification()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  -- No-op when agreed_terms is not changing.
+  IF OLD.agreed_terms IS NOT DISTINCT FROM NEW.agreed_terms THEN
+    RETURN NEW;
+  END IF;
+
+  -- Terms may only change while the trade is still in a
+  -- pre-acceptance phase. Once the contract is locked (status
+  -- moves to 'accepted' or beyond), the field is immutable.
+  IF OLD.status NOT IN ('pending_offer', 'negotiating') THEN
+    RAISE EXCEPTION
+      'Trade %: agreed_terms is locked once the contract is accepted (current status: "%").',
+      OLD.id, OLD.status
+    USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trades_lock_agreed_terms
+  BEFORE UPDATE ON trades
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_agreed_terms_modification();


### PR DESCRIPTION
## Summary
- Adds a PostgreSQL trigger (`trades_lock_agreed_terms`) that raises `check_violation` (SQLSTATE `23514`) if `agreed_terms` is updated after the trade leaves the negotiation phase — closes the gap between the schema comment "frozen at accepted" and actual enforcement
- Adds `updateAgreedTermsAction` Server Action as the sole validated write path for `agreed_terms`; rejects changes when status is not `pending_offer` or `negotiating`, and maps the DB `23514` error to a user-facing lock message
- Adds 16 unit tests covering auth, empty/whitespace input, lock enforcement across all post-acceptance statuses, DB payload shape, and the trigger bypass path

## Changes
| File | Change |
|------|--------|
| `supabase/migrations/20260421000002_contract_locking.sql` | New trigger — `prevent_agreed_terms_modification` + `trades_lock_agreed_terms` |
| `src/actions/trades.ts` | New `updateAgreedTermsAction` Server Action |
| `src/actions/__tests__/trades.test.ts` | 16 new tests for `updateAgreedTermsAction` |

## How the lock works end-to-end
1. **Negotiation phase** (`pending_offer` / `negotiating`): either party calls `updateAgreedTermsAction` to propose or refine terms.
2. **"Request Swap" click**: `updateTradeStatusAction` transitions to `accepted`, setting `accepted_at`. From that moment:
   - The **Server Action guard** rejects term changes with `"Agreed terms are locked once the contract is accepted."`
   - The **DB trigger** provides a second enforcement layer — even a direct Supabase write attempt is rejected at the database with `check_violation`.
3. State changes post-acceptance remain restricted to involved parties via existing RLS + `validate_trade_transition` trigger.

> **Migration note:** `20260421000002_contract_locking.sql` must be applied via the Supabase MCP (`mcp__supabase__apply_migration`) or the Supabase dashboard before this branch is deployed.

## Test plan
- [x] All unit tests pass (`npm run test`) — 222 tests, 10 files
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual smoke test: call `updateAgreedTermsAction(tradeId, "Borrow drill for 2 days")` while in `negotiating`; verify it succeeds. Transition to `accepted` via "Request Swap"; verify the same call returns the lock error.

## Security checklist
- [x] No secrets committed (Gitleaks passes in pre-commit)
- [x] No new Supabase tables — migration only adds a trigger on existing `trades` table
- [x] No Groq calls — feature is pure state-machine enforcement, no AI inference
- [x] `updateAgreedTermsAction` validates: auth, non-empty input, party membership, mutable-phase status
- [x] No `any` types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)