### PR TITLE
feat(trades): 5-step transaction workflow with direct lender accept

### DIFF
--- a/src/actions/__tests__/trades.test.ts
+++ b/src/actions/__tests__/trades.test.ts
@@ -23,7 +23,7 @@ const mockConflictMaybeSingle = vi.fn()
 const mockConflictLimit = vi.fn().mockReturnValue({ maybeSingle: mockConflictMaybeSingle })
 const mockConflictIn = vi.fn().mockReturnValue({ limit: mockConflictLimit })
 const mockConflictNeq = vi.fn().mockReturnValue({ in: mockConflictIn })
-const mockConflictEq = vi.fn().mockReturnValue({ neq: mockConflictNeq })
+const mockConflictEq = vi.fn().mockReturnValue({ neq: mockConflictNeq, in: mockConflictIn })
 
 // Differentiate chains by column argument: 'id' → conflict check, anything else → fetch
 const mockFetchSelect = vi.fn().mockImplementation((columns: string) => {
@@ -89,6 +89,8 @@ describe('createTradeAction', () => {
     vi.clearAllMocks()
     mockGetUser.mockResolvedValue({ data: { user: CREATE_USER }, error: null })
     mockInsertSingle.mockResolvedValue({ data: { id: NEW_TRADE_ID }, error: null })
+    // Default: item is not currently borrowed
+    mockConflictMaybeSingle.mockResolvedValue({ data: null, error: null })
   })
 
   it('returns error when user is not authenticated', async () => {
@@ -156,6 +158,16 @@ describe('createTradeAction', () => {
       makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
     )
     expect(mockRedirect).toHaveBeenCalledWith(`/chat/${NEW_TRADE_ID}`)
+  })
+
+  it('returns error when item is currently borrowed (in_progress)', async () => {
+    mockConflictMaybeSingle.mockResolvedValue({ data: { id: 'existing-trade-999' }, error: null })
+    const result = await createTradeAction(
+      CREATE_PREV_STATE,
+      makeFormData({ item_id: CREATE_ITEM_ID, counterparty_id: CREATE_COUNTERPARTY_ID })
+    )
+    expect(result.error).toMatch(/currently borrowed/i)
+    expect(mockInsert).not.toHaveBeenCalled()
   })
 })
 
@@ -241,6 +253,20 @@ describe('updateTradeStatusAction', () => {
     expect(result.error).toBeNull()
   })
 
+  it('counterparty can accept directly from pending_offer (skipping negotiating)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toBeNull()
+  })
+
+  it('initiator cannot accept their own pending_offer', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'accepted')
+    expect(result.error).toMatch(/counterparty/i)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
   it('allows the initiator to cancel from pending_offer', async () => {
     mockFetchSingle.mockResolvedValue({ data: makeTrade('pending_offer'), error: null })
     const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
@@ -290,6 +316,19 @@ describe('updateTradeStatusAction', () => {
     expect(result.error).toBeNull()
   })
 
+  it('allows initiator to cancel from accepted (back out before pickup)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    expect(result.error).toBeNull()
+  })
+
+  it('allows counterparty to cancel from accepted (back out before pickup)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: COUNTERPARTY_ID } } })
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'cancelled')
+    expect(result.error).toBeNull()
+  })
+
   // ── Lifecycle timestamps ────────────────────────────────────────────────────
 
   it('sets accepted_at when transitioning to accepted', async () => {
@@ -330,6 +369,14 @@ describe('updateTradeStatusAction', () => {
     const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
     expect(result.error).toMatch(/already part of an active trade/i)
     expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('conflict check only considers in_progress trades (completed items can be re-borrowed)', async () => {
+    mockFetchSingle.mockResolvedValue({ data: makeTrade('accepted'), error: null })
+    // No in_progress conflict — a completed trade for the same item should not block pickup
+    mockConflictMaybeSingle.mockResolvedValue({ data: null, error: null })
+    const result = await updateTradeStatusAction(TRADE_ID, 'in_progress')
+    expect(result.error).toBeNull()
   })
 
   it('returns clear error for 23505 unique violation (race condition bypasses pre-flight)', async () => {

--- a/src/actions/trades.ts
+++ b/src/actions/trades.ts
@@ -34,6 +34,16 @@ export async function createTradeAction(
 
   if (user.id === counterparty_id) return { error: 'You cannot swap with yourself.' }
 
+  const { data: locked } = await supabase
+    .from('trades')
+    .select('id')
+    .eq('item_id', item_id)
+    .in('status', ['in_progress'])
+    .limit(1)
+    .maybeSingle()
+
+  if (locked) return { error: 'This item is currently borrowed and cannot be requested.' }
+
   const { data, error } = await supabase
     .from('trades')
     .insert({ initiator_id: user.id, counterparty_id, item_id, status: 'pending_offer' })
@@ -99,7 +109,7 @@ export async function updateTradeStatusAction(
       .select('id')
       .eq('item_id', trade.item_id)
       .neq('id', tradeId)
-      .in('status', ['in_progress', 'completed'])
+      .in('status', ['in_progress'])
       .limit(1)
       .maybeSingle()
 
@@ -242,7 +252,7 @@ export async function updateAgreedTermsAction(
 // System event messages inserted into the chat when milestone transitions occur.
 // Keyed by the new status.
 const SYSTEM_EVENTS: Partial<Record<TradeStatus, { content: string; event_type: string }>> = {
-  accepted: { content: 'Deal accepted', event_type: 'status:accepted' },
+  accepted: { content: 'Swap request accepted', event_type: 'status:accepted' },
   in_progress: { content: 'Pickup confirmed', event_type: 'status:in_progress' },
   completed: { content: 'Return confirmed', event_type: 'status:completed' },
   cancelled: { content: 'Trade cancelled', event_type: 'status:cancelled' },

--- a/src/app/(main)/chat/[tradeId]/page.tsx
+++ b/src/app/(main)/chat/[tradeId]/page.tsx
@@ -97,7 +97,12 @@ export default async function TradeChatPage({ params }: PageProps) {
       />
 
       {/* Real-time chat */}
-      <ChatWindow tradeId={tradeId} currentUserId={user.id} initialMessages={initialMessages} />
+      <ChatWindow
+        tradeId={tradeId}
+        currentUserId={user.id}
+        initialMessages={initialMessages}
+        initialStatus={t.status}
+      />
     </div>
   )
 }

--- a/src/app/(main)/listings/[id]/page.tsx
+++ b/src/app/(main)/listings/[id]/page.tsx
@@ -39,11 +39,22 @@ export default async function ItemDetailPage({ params }: Props) {
 
   const item = itemData as Listing
 
-  const { data: providerData } = await supabase
-    .from('users')
-    .select('id, full_name, avatar_url, trust_score')
-    .eq('id', item.provider_id)
-    .single()
+  const [{ data: providerData }, { data: activeTradeData }] = await Promise.all([
+    supabase
+      .from('users')
+      .select('id, full_name, avatar_url, trust_score')
+      .eq('id', item.provider_id)
+      .single(),
+    supabase
+      .from('trades')
+      .select('id')
+      .eq('item_id', id)
+      .eq('status', 'in_progress')
+      .limit(1)
+      .maybeSingle(),
+  ])
+
+  const isLocked = !!activeTradeData
 
   const provider = providerData as Pick<
     UserProfile,
@@ -149,7 +160,11 @@ export default async function ItemDetailPage({ params }: Props) {
         {isOwner ? (
           <p className="text-sm italic text-gray-400">This is your listing.</p>
         ) : user ? (
-          <RequestSwapButton itemId={item.id} counterpartyId={item.provider_id} />
+          <RequestSwapButton
+            itemId={item.id}
+            counterpartyId={item.provider_id}
+            isLocked={isLocked}
+          />
         ) : (
           <Link
             href="/login"

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,23 +1,32 @@
 'use client'
 
 import { useChat } from '@/hooks/useChat'
+import { useTrade } from '@/hooks/useTrade'
 import MessageList from './MessageList'
 import MessageForm from './MessageForm'
 import type { Message } from '@/types/messages'
+import type { TradeStatus } from '@/types/trades'
 
 interface ChatWindowProps {
   tradeId: string
   currentUserId: string
   initialMessages: Message[]
+  initialStatus: TradeStatus
 }
 
-export default function ChatWindow({ tradeId, currentUserId, initialMessages }: ChatWindowProps) {
+export default function ChatWindow({
+  tradeId,
+  currentUserId,
+  initialMessages,
+  initialStatus,
+}: ChatWindowProps) {
   const messages = useChat(tradeId, initialMessages)
+  const status = useTrade(tradeId, initialStatus)
 
   return (
     <div className="flex h-full flex-col">
       <MessageList messages={messages} currentUserId={currentUserId} />
-      <MessageForm tradeId={tradeId} />
+      <MessageForm tradeId={tradeId} tradeStatus={status} />
     </div>
   )
 }

--- a/src/components/chat/MessageForm.tsx
+++ b/src/components/chat/MessageForm.tsx
@@ -3,12 +3,15 @@
 import { useState, useTransition } from 'react'
 import { Send } from 'lucide-react'
 import { sendMessageAction } from '@/actions/messages'
+import { TERMINAL_STATUSES } from '@/types/trades'
+import type { TradeStatus } from '@/types/trades'
 
 interface MessageFormProps {
   tradeId: string
+  tradeStatus: TradeStatus
 }
 
-export default function MessageForm({ tradeId }: MessageFormProps) {
+export default function MessageForm({ tradeId, tradeStatus }: MessageFormProps) {
   const [content, setContent] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
@@ -39,6 +42,25 @@ export default function MessageForm({ tradeId }: MessageFormProps) {
       if (!text || isPending) return
       submitMessage(text)
     }
+  }
+
+  if (tradeStatus === 'pending_offer') {
+    return (
+      <div className="border-t border-gray-200 p-4">
+        <p className="text-center text-sm text-gray-400">
+          Waiting for the provider to accept your swap request.
+        </p>
+      </div>
+    )
+  }
+
+  const isTerminal = (TERMINAL_STATUSES as readonly string[]).includes(tradeStatus)
+  if (isTerminal) {
+    return (
+      <div className="border-t border-gray-200 p-4">
+        <p className="text-center text-sm text-gray-400">This conversation is closed.</p>
+      </div>
+    )
   }
 
   return (

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -10,7 +10,7 @@ interface MessageListProps {
 }
 
 const EVENT_CONFIG: Record<string, { label: string; Icon: React.ElementType; color: string }> = {
-  'status:accepted': { label: 'Deal accepted', Icon: CheckCircle, color: 'text-green-600' },
+  'status:accepted': { label: 'Swap request accepted', Icon: CheckCircle, color: 'text-green-600' },
   'status:in_progress': { label: 'Pickup confirmed', Icon: Package, color: 'text-purple-600' },
   'status:completed': { label: 'Return confirmed', Icon: CheckCircle, color: 'text-blue-600' },
   'status:cancelled': { label: 'Trade cancelled', Icon: XCircle, color: 'text-gray-500' },
@@ -19,7 +19,7 @@ const EVENT_CONFIG: Record<string, { label: string; Icon: React.ElementType; col
 
 // First-person labels when the current user performed the action.
 const MY_EVENT_LABELS: Record<string, string> = {
-  'status:accepted': 'You accepted the deal',
+  'status:accepted': 'You accepted the swap request',
   'status:in_progress': 'You confirmed pickup',
   'status:completed': 'You confirmed return',
   'status:cancelled': 'You cancelled the trade',

--- a/src/components/chat/TradeStatusPanel.tsx
+++ b/src/components/chat/TradeStatusPanel.tsx
@@ -27,6 +27,7 @@ interface Transition {
 // Text shown in the inline confirmation prompt before executing a
 // possession-transfer transition.
 const CONFIRMATION_PROMPTS: Partial<Record<TradeStatus, string>> = {
+  accepted: 'This confirms you are accepting the swap request. The borrower will be notified.',
   in_progress:
     'This records that the item has been picked up and you are now responsible for its safe return.',
   completed: 'This records that the item has been returned to the provider.',
@@ -41,19 +42,28 @@ const REASON_PLACEHOLDERS: Partial<Record<TradeStatus, string>> = {
 const TRANSITIONS: Partial<Record<TradeStatus, Transition[]>> = {
   pending_offer: [
     {
-      next: 'negotiating',
-      label: 'Start Inquiry',
+      next: 'accepted',
+      label: 'Accept Request',
       forInitiator: false,
       forCounterparty: true,
       danger: false,
-      requiresConfirmation: false,
+      requiresConfirmation: true,
       requiresReason: false,
     },
     {
       next: 'cancelled',
-      label: 'Cancel',
-      forInitiator: true,
+      label: 'Decline',
+      forInitiator: false,
       forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
+    },
+    {
+      next: 'cancelled',
+      label: 'Withdraw Request',
+      forInitiator: true,
+      forCounterparty: false,
       danger: true,
       requiresConfirmation: true,
       requiresReason: true,
@@ -88,6 +98,15 @@ const TRANSITIONS: Partial<Record<TradeStatus, Transition[]>> = {
       danger: false,
       requiresConfirmation: true,
       requiresReason: false,
+    },
+    {
+      next: 'cancelled',
+      label: 'Cancel',
+      forInitiator: true,
+      forCounterparty: true,
+      danger: true,
+      requiresConfirmation: true,
+      requiresReason: true,
     },
     {
       next: 'disputed',
@@ -203,7 +222,7 @@ export default function TradeStatusPanel({
   const status = useTrade(tradeId, initialStatus)
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
-  const [confirmingNext, setConfirmingNext] = useState<TradeStatus | null>(null)
+  const [confirmingTransition, setConfirmingTransition] = useState<Transition | null>(null)
   const [reasonText, setReasonText] = useState('')
 
   const isInitiator = currentUserId === initiatorId
@@ -213,31 +232,30 @@ export default function TradeStatusPanel({
 
   const availableTransitions = getAvailableTransitions(status, isInitiator, isCounterparty)
 
-  const confirmingTransition = availableTransitions.find((t) => t.next === confirmingNext)
   const confirmingNeedsReason = confirmingTransition?.requiresReason ?? false
 
   function handleTransitionClick(t: Transition) {
     setError(null)
     if (t.requiresConfirmation || t.requiresReason) {
-      setConfirmingNext(t.next)
+      setConfirmingTransition(t)
     } else {
       executeTransition(t.next)
     }
   }
 
   function handleConfirm() {
-    if (confirmingNext) {
-      executeTransition(confirmingNext, confirmingNeedsReason ? reasonText : undefined)
+    if (confirmingTransition) {
+      executeTransition(confirmingTransition.next, confirmingNeedsReason ? reasonText : undefined)
     }
   }
 
   function handleCancelConfirm() {
-    setConfirmingNext(null)
+    setConfirmingTransition(null)
     setReasonText('')
   }
 
   function executeTransition(next: TradeStatus, reason?: string) {
-    setConfirmingNext(null)
+    setConfirmingTransition(null)
     setReasonText('')
     startTransition(async () => {
       const result = await updateTradeStatusAction(tradeId, next, reason?.trim() || undefined)
@@ -257,7 +275,7 @@ export default function TradeStatusPanel({
         </span>
 
         {/* Inline confirmation prompt or action buttons */}
-        {confirmingNext ? (
+        {confirmingTransition ? (
           <div className="min-w-0 flex-1">
             {confirmingNeedsReason ? (
               // Reason-input flow: stacked layout with optional textarea
@@ -265,7 +283,9 @@ export default function TradeStatusPanel({
                 <textarea
                   value={reasonText}
                   onChange={(e) => setReasonText(e.target.value)}
-                  placeholder={REASON_PLACEHOLDERS[confirmingNext] ?? 'Add a reason (optional)…'}
+                  placeholder={
+                    REASON_PLACEHOLDERS[confirmingTransition.next] ?? 'Add a reason (optional)…'
+                  }
                   disabled={isPending}
                   rows={2}
                   className="w-full resize-none rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs text-gray-700 placeholder-gray-400 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 disabled:opacity-50"
@@ -292,7 +312,7 @@ export default function TradeStatusPanel({
               // Possession-confirmation flow: single-line prompt with confirm/back
               <div className="flex items-center gap-2">
                 <p className="min-w-0 truncate text-xs text-gray-600">
-                  {CONFIRMATION_PROMPTS[confirmingNext] ?? 'Are you sure?'}
+                  {CONFIRMATION_PROMPTS[confirmingTransition.next] ?? 'Are you sure?'}
                 </p>
                 <div className="flex shrink-0 items-center gap-1.5">
                   <button
@@ -319,7 +339,7 @@ export default function TradeStatusPanel({
             <div className="flex items-center gap-2">
               {availableTransitions.map((t) => (
                 <button
-                  key={t.next}
+                  key={t.label}
                   onClick={() => handleTransitionClick(t)}
                   disabled={isPending}
                   className={`inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/src/components/chat/__tests__/TradeStatusPanel.test.ts
+++ b/src/components/chat/__tests__/TradeStatusPanel.test.ts
@@ -8,50 +8,64 @@ import { getAvailableTransitions } from '../TradeStatusPanel'
 describe('getAvailableTransitions', () => {
   // ── pending_offer ──────────────────────────────────────────────────────────
 
-  it('pending_offer: counterparty can start inquiry or cancel', () => {
+  it('pending_offer: counterparty can accept or decline the request', () => {
     const nexts = getAvailableTransitions('pending_offer', false, true).map((t) => t.next)
-    expect(nexts).toContain('negotiating')
+    expect(nexts).toContain('accepted')
     expect(nexts).toContain('cancelled')
   })
 
-  it('pending_offer: initiator can only cancel (not start inquiry)', () => {
+  it('pending_offer: counterparty does not see negotiating (legacy step hidden)', () => {
+    const nexts = getAvailableTransitions('pending_offer', false, true).map((t) => t.next)
+    expect(nexts).not.toContain('negotiating')
+  })
+
+  it('pending_offer: initiator can only withdraw (not accept)', () => {
     const nexts = getAvailableTransitions('pending_offer', true, false).map((t) => t.next)
+    expect(nexts).not.toContain('accepted')
     expect(nexts).not.toContain('negotiating')
     expect(nexts).toContain('cancelled')
   })
 
-  it('pending_offer: start inquiry button is labeled "Start Inquiry"', () => {
+  it('pending_offer: Accept Request button is labeled "Accept Request"', () => {
     const t = getAvailableTransitions('pending_offer', false, true).find(
-      (x) => x.next === 'negotiating'
+      (x) => x.next === 'accepted'
     )
-    expect(t?.label).toBe('Start Inquiry')
+    expect(t?.label).toBe('Accept Request')
   })
 
-  it('pending_offer: start inquiry is not a danger action', () => {
+  it('pending_offer: Accept Request is not a danger action', () => {
     const t = getAvailableTransitions('pending_offer', false, true).find(
-      (x) => x.next === 'negotiating'
+      (x) => x.next === 'accepted'
     )
     expect(t?.danger).toBe(false)
   })
 
-  it('pending_offer: start inquiry does not require confirmation', () => {
+  it('pending_offer: Accept Request requires confirmation', () => {
     const t = getAvailableTransitions('pending_offer', false, true).find(
-      (x) => x.next === 'negotiating'
+      (x) => x.next === 'accepted'
     )
-    expect(t?.requiresConfirmation).toBe(false)
+    expect(t?.requiresConfirmation).toBe(true)
   })
 
-  it('pending_offer: cancel is a danger action', () => {
+  it('pending_offer: counterparty cancel is labeled "Decline"', () => {
+    const t = getAvailableTransitions('pending_offer', false, true).find(
+      (x) => x.next === 'cancelled'
+    )
+    expect(t?.label).toBe('Decline')
+  })
+
+  it('pending_offer: initiator cancel is labeled "Withdraw Request"', () => {
+    const t = getAvailableTransitions('pending_offer', true, false).find(
+      (x) => x.next === 'cancelled'
+    )
+    expect(t?.label).toBe('Withdraw Request')
+  })
+
+  it('pending_offer: Decline is a danger action that requires confirmation and a reason', () => {
     const t = getAvailableTransitions('pending_offer', false, true).find(
       (x) => x.next === 'cancelled'
     )
     expect(t?.danger).toBe(true)
-  })
-
-  it('pending_offer: cancel requires confirmation and a reason', () => {
-    const t = getAvailableTransitions('pending_offer', false, true).find(
-      (x) => x.next === 'cancelled'
-    )
     expect(t?.requiresConfirmation).toBe(true)
     expect(t?.requiresReason).toBe(true)
   })
@@ -120,6 +134,20 @@ describe('getAvailableTransitions', () => {
   it('accepted: confirm pickup does not require a reason', () => {
     const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'in_progress')
     expect(t?.requiresReason).toBe(false)
+  })
+
+  it('accepted: both parties can cancel before pickup', () => {
+    const initiatorNexts = getAvailableTransitions('accepted', true, false).map((t) => t.next)
+    const counterpartyNexts = getAvailableTransitions('accepted', false, true).map((t) => t.next)
+    expect(initiatorNexts).toContain('cancelled')
+    expect(counterpartyNexts).toContain('cancelled')
+  })
+
+  it('accepted: cancel is a danger action requiring confirmation and a reason', () => {
+    const t = getAvailableTransitions('accepted', true, false).find((x) => x.next === 'cancelled')
+    expect(t?.danger).toBe(true)
+    expect(t?.requiresConfirmation).toBe(true)
+    expect(t?.requiresReason).toBe(true)
   })
 
   // ── scheduled ─────────────────────────────────────────────────────────────

--- a/src/components/listings/RequestSwapButton.tsx
+++ b/src/components/listings/RequestSwapButton.tsx
@@ -4,19 +4,33 @@
 // Client component — submits a trade offer via createTradeAction.
 
 import { useActionState, useTransition } from 'react'
-import { ArrowRightLeft } from 'lucide-react'
+import { ArrowRightLeft, Package } from 'lucide-react'
 import { createTradeAction, type CreateTradeResult } from '@/actions/trades'
 
 interface RequestSwapButtonProps {
   itemId: string
   counterpartyId: string
+  isLocked?: boolean
 }
 
 const initialState: CreateTradeResult = { error: null }
 
-export default function RequestSwapButton({ itemId, counterpartyId }: RequestSwapButtonProps) {
+export default function RequestSwapButton({
+  itemId,
+  counterpartyId,
+  isLocked = false,
+}: RequestSwapButtonProps) {
   const [state, formAction] = useActionState(createTradeAction, initialState)
   const [isPending, startTransition] = useTransition()
+
+  if (isLocked) {
+    return (
+      <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-100 px-5 py-2.5 text-sm font-semibold text-gray-500">
+        <Package className="h-4 w-4" aria-hidden />
+        Currently borrowed
+      </div>
+    )
+  }
 
   function handleSubmit(formData: FormData) {
     startTransition(() => formAction(formData))

--- a/src/types/trades.ts
+++ b/src/types/trades.ts
@@ -48,6 +48,7 @@ export interface ValidTransition {
 
 export const VALID_TRANSITIONS: Partial<Record<TradeStatus, ValidTransition[]>> = {
   pending_offer: [
+    { next: 'accepted', roles: ['counterparty'] },
     { next: 'negotiating', roles: ['counterparty'] },
     { next: 'cancelled', roles: ['initiator', 'counterparty'] },
   ],
@@ -57,6 +58,7 @@ export const VALID_TRANSITIONS: Partial<Record<TradeStatus, ValidTransition[]>> 
   ],
   accepted: [
     { next: 'in_progress', roles: ['initiator'] },
+    { next: 'cancelled', roles: ['initiator', 'counterparty'] },
     { next: 'disputed', roles: ['initiator', 'counterparty'] },
   ],
   scheduled: [{ next: 'in_progress', roles: ['initiator'] }],

--- a/supabase/migrations/20260421000003_fix_trade_workflow.sql
+++ b/supabase/migrations/20260421000003_fix_trade_workflow.sql
@@ -1,0 +1,68 @@
+-- supabase/migrations/20260421000003_fix_trade_workflow.sql
+-- ============================================================
+-- NeighborSwap — Trade workflow corrections
+--
+-- Three targeted fixes:
+--
+-- 1. Allow pending_offer → accepted (lender accepts a swap request
+--    directly without the two-step Start Inquiry → Request Swap flow).
+--
+-- 2. Allow accepted → cancelled (either party can back out between
+--    acceptance and physical pickup).
+--
+-- 3. Fix the item-lock unique index so it covers only in_progress,
+--    NOT completed.  Previously a completed trade permanently blocked
+--    the item from ever being borrowed again.
+-- ============================================================
+
+-- ── 1 & 2: Update the state machine trigger ──────────────────────────────────
+
+CREATE OR REPLACE FUNCTION validate_trade_transition()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  -- No-op when status is unchanged (e.g. updating logistics_data only)
+  IF OLD.status = NEW.status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Terminal statuses are immutable
+  IF OLD.status IN ('completed', 'cancelled', 'disputed', 'flagged') THEN
+    RAISE EXCEPTION
+      'Trade %: status "%" is terminal and cannot be changed.',
+      OLD.id, OLD.status
+    USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Validate the specific transition
+  IF NOT (
+    -- INQUIRY phase: lender can accept directly (new) or start negotiation (legacy)
+    (OLD.status = 'pending_offer'  AND NEW.status IN ('negotiating', 'accepted', 'cancelled'))             OR
+    (OLD.status = 'negotiating'    AND NEW.status IN ('accepted', 'cancelled'))                            OR
+    -- ACCEPTED: initiator confirms pickup; either party can cancel before pickup (new) or dispute
+    (OLD.status = 'accepted'       AND NEW.status IN ('in_progress', 'scheduled', 'flagged', 'disputed', 'cancelled')) OR
+    -- SCHEDULED: logistics agent placed this; initiator confirms pickup
+    (OLD.status = 'scheduled'      AND NEW.status IN ('in_progress'))                                      OR
+    -- IN_PROGRESS: lender confirms return; either party can dispute
+    (OLD.status = 'in_progress'    AND NEW.status IN ('completed', 'disputed'))
+  ) THEN
+    RAISE EXCEPTION
+      'Trade %: invalid transition "%" → "%".',
+      OLD.id, OLD.status, NEW.status
+    USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ── 3: Fix item-lock index (in_progress only, not completed) ─────────────────
+--
+-- Drop the old index that locked items permanently after completion, then
+-- recreate it covering only the in_progress status.  After a lender
+-- confirms return (→ completed) the item becomes available for new swaps.
+
+DROP INDEX IF EXISTS idx_trades_item_one_active;
+
+CREATE UNIQUE INDEX idx_trades_item_one_active
+  ON trades (item_id)
+  WHERE status = 'in_progress';


### PR DESCRIPTION
## Summary
- Lender (counterparty) can now accept a swap request directly from \`pending_offer → accepted\`, skipping the old two-step Start Inquiry flow
- Both parties can cancel after acceptance but before pickup (\`accepted → cancelled\`)
- Item lock prevents new swap requests while an item is \`in_progress\`; borrower sees "Currently borrowed" badge on the listing page
- MessageForm is gated on trade status — borrower sees a waiting banner at \`pending_offer\`, closed banner at terminal statuses
- DB migration fixes the unique index so completed items can be re-borrowed

## Changes
| File | Change |
|------|--------|
| \`supabase/migrations/20260421000003_fix_trade_workflow.sql\` | New migration: allow \`pending_offer→accepted\`, \`accepted→cancelled\`; item-lock index covers \`in_progress\` only |
| \`src/types/trades.ts\` | Added two new transitions to \`VALID_TRANSITIONS\` |
| \`src/actions/trades.ts\` | Item lock pre-check in \`createTradeAction\`; conflict check reduced to \`in_progress\`; event label update |
| \`src/components/chat/TradeStatusPanel.tsx\` | "Accept Request"/"Decline"/"Withdraw Request" at \`pending_offer\`; "Cancel" at \`accepted\` |
| \`src/components/chat/ChatWindow.tsx\` | Propagates live trade status to \`MessageForm\` |
| \`src/components/chat/MessageForm.tsx\` | Status-gated input: waiting/closed banners |
| \`src/app/(main)/chat/[tradeId]/page.tsx\` | Passes \`initialStatus\` to \`ChatWindow\` |
| \`src/app/(main)/listings/[id]/page.tsx\` | Checks for active \`in_progress\` trade; passes \`isLocked\` |
| \`src/components/listings/RequestSwapButton.tsx\` | "Currently borrowed" badge when \`isLocked\` |
| \`src/components/chat/MessageList.tsx\` | Event label: "Deal accepted" → "Swap request accepted" |
| \`src/actions/__tests__/trades.test.ts\` | 6 new tests; mock chain fix for \`createTradeAction\` lock check |
| \`src/components/chat/__tests__/TradeStatusPanel.test.ts\` | Updated + 5 new tests for new \`pending_offer\` and \`accepted\` transitions |

## Test plan
- [ ] All unit tests pass (`npm run test`) — 253/253 ✅
- [ ] TypeScript compiles clean (`npx tsc --noEmit`) ✅
- [ ] Lint passes (`npm run lint`) ✅
- [ ] Build succeeds (`npm run build`) ✅
- [ ] Manual smoke test:
  1. Browse to a listing you do not own — confirm "Request Swap" button is visible
  2. Submit the swap request — you land in chat, see "Pending offer" status badge and waiting banner (no text input)
  3. Log in as the lender — see "Accept Request" and "Decline" buttons; click Accept Request, confirm
  4. Status flips to "Accepted"; chat input now visible to both parties; system event reads "Swap request accepted"
  5. As borrower, click "Confirm Pickup" → \`in_progress\`; lender sees "Confirm Return"
  6. Go back to the listing page as any user — confirm "Currently borrowed" badge replaces the Request Swap button
  7. As lender, confirm return → \`completed\`; return to listing — "Request Swap" button is back
  8. Try requesting the same item again — succeeds (no "currently borrowed" block)

## Security checklist
- [ ] No secrets committed (Gitleaks)
- [ ] RLS enabled on any new Supabase tables — no new tables; existing trades/items tables unchanged
- [ ] PII stripped from Groq prompts — no new Groq calls
- [ ] All Server Actions validate input with Zod — existing Zod validation unchanged; new lock check is additive
- [ ] No \`any\` types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)