### PR TITLE
fix(realtime): use Supabase Realtime for live trade status updates

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -2,9 +2,16 @@
 
 // src/hooks/useTrade.ts
 // Subscribes to real-time trade status updates for a single trade.
+//
+// Primary path: Supabase Realtime (postgres_changes) — works on all
+// deployments including Vercel, no custom server required.
+//
+// Secondary path: Socket.io — active when the custom server.ts is running
+// locally and emits the event after each DB write.
 
 import { useEffect, useState } from 'react'
 import { useSocket } from './useSocket'
+import { createClient } from '@/lib/supabase/client'
 import { SOCKET_EVENTS } from '@/lib/socket'
 import type { TradeStatusPayload } from '@/lib/socket'
 import type { TradeStatus } from '@/types/trades'
@@ -17,6 +24,35 @@ export function useTrade(tradeId: string, initialStatus: TradeStatus): TradeStat
     setStatus(initialStatus)
   }, [initialStatus])
 
+  // ── Supabase Realtime (primary) ──────────────────────────────────────────
+  // Subscribes to postgres_changes on the trades row.  Fires on every UPDATE
+  // regardless of which server process caused it.
+  useEffect(() => {
+    const supabase = createClient()
+    const channel = supabase
+      .channel(`trade-status-${tradeId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'trades',
+          filter: `id=eq.${tradeId}`,
+        },
+        (payload) => {
+          const newStatus = (payload.new as { status: string }).status as TradeStatus
+          setStatus(newStatus)
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [tradeId])
+
+  // ── Socket.io (secondary) ────────────────────────────────────────────────
+  // Only fires when the custom server.ts is running locally.
   useEffect(() => {
     if (!socket) return
 

--- a/supabase/migrations/20260421000004_enable_trades_realtime.sql
+++ b/supabase/migrations/20260421000004_enable_trades_realtime.sql
@@ -1,0 +1,13 @@
+-- supabase/migrations/20260421000004_enable_trades_realtime.sql
+-- ============================================================
+-- Enable Supabase Realtime CDC on the trades table so that
+-- client-side postgres_changes subscriptions receive status
+-- update events without needing the custom Socket.io server.
+-- ============================================================
+
+-- REPLICA IDENTITY FULL makes the full row available in the
+-- Realtime payload (old + new).  Required for row-level filters
+-- (filter: `id=eq.<uuid>`) to work on UPDATE events.
+ALTER TABLE trades REPLICA IDENTITY FULL;
+
+ALTER PUBLICATION supabase_realtime ADD TABLE trades;


### PR DESCRIPTION
Socket.io emitToRoom is a no-op on Vercel (serverless) because globalThis.__socketIo is only set by the custom server.ts process. Users had to reload the page to see status changes after any action.

Fix: subscribe to postgres_changes on the trades table in useTrade. Supabase Realtime works on all deployments without a custom server. Socket.io kept as secondary path for local custom-server runs.

Also adds the required DB migration:
- ALTER TABLE trades REPLICA IDENTITY FULL (row-level filter support)
- ALTER PUBLICATION supabase_realtime ADD TABLE trades