### PR TITLE
fix(realtime): unique channel name avoids subscribe() error on remount

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -27,10 +27,16 @@ export function useTrade(tradeId: string, initialStatus: TradeStatus): TradeStat
   // ── Supabase Realtime (primary) ──────────────────────────────────────────
   // Subscribes to postgres_changes on the trades row.  Fires on every UPDATE
   // regardless of which server process caused it.
+  //
+  // The channel name includes Date.now() so each effect invocation registers
+  // a fresh channel.  createBrowserClient() returns a singleton — without the
+  // unique suffix, StrictMode's double-invoke (or any remount) would call
+  // .on() on the already-subscribed channel and throw
+  // "cannot add callbacks after subscribe()".
   useEffect(() => {
     const supabase = createClient()
     const channel = supabase
-      .channel(`trade-status-${tradeId}`)
+      .channel(`trade-status-${tradeId}-${Date.now()}`)
       .on(
         'postgres_changes',
         {


### PR DESCRIPTION
createBrowserClient returns a singleton. Calling .channel('same-name') on an already-subscribed channel and then .on() throws:
  "cannot add postgres_changes callbacks after subscribe()"

Fix: append Date.now() to the channel name so each effect invocation registers a brand-new channel. The cleanup still calls removeChannel() to unsubscribe and clear it from the client's internal registry.