### PR TITLE
fix(realtime): use crypto.randomUUID() to prevent channel reuse crash

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -35,8 +35,12 @@ export function useTrade(tradeId: string, initialStatus: TradeStatus): TradeStat
   // "cannot add callbacks after subscribe()".
   useEffect(() => {
     const supabase = createClient()
+    // crypto.randomUUID() is collision-free even within the same millisecond.
+    // Date.now() is NOT safe: two effect invocations in the same ms produce
+    // the same topic name, RealtimeClient.channel() finds the still-joined
+    // channel in its registry, and .on() throws "after subscribe()".
     const channel = supabase
-      .channel(`trade-status-${tradeId}-${Date.now()}`)
+      .channel(`trade-status-${tradeId}-${crypto.randomUUID()}`)
       .on(
         'postgres_changes',
         {


### PR DESCRIPTION
Date.now() is not collision-free: two effect invocations in the same millisecond (StrictMode double-invoke, rapid re-renders) produce the same topic name. RealtimeClient.channel() finds that topic in its internal registry, returns the already-subscribed channel, and calling .on() on it throws "cannot add postgres_changes callbacks after subscribe()". The channel is only removed from the registry after the async unsubscribe→teardown→_onClose chain completes, so even a tiny timing gap causes the lookup to succeed.

crypto.randomUUID() generates a 128-bit UUID per invocation — no collision is possible even within the same tick.