### PR TITLE
feat(home): show full nav on landing page; admin sees Dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   Sprout,
   Leaf,
   MessageSquare,
+  BarChart2,
 } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import UserMenu from '@/components/UserMenu'
@@ -49,6 +50,12 @@ export default async function Home() {
     data: { user },
   } = await supabase.auth.getUser()
 
+  let isAdmin = false
+  if (user) {
+    const { data } = await supabase.from('users').select('is_admin').eq('id', user.id).single()
+    isAdmin = data?.is_admin ?? false
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
       {/* ── Nav ── */}
@@ -63,29 +70,50 @@ export default async function Home() {
           </Link>
 
           {/* Auth actions */}
-          <nav className="flex items-center gap-3">
+          <nav className="flex items-center gap-3 text-sm">
             {user ? (
               <>
+                <Link href="/listings" className="text-gray-600 hover:text-gray-900">
+                  Browse
+                </Link>
+                <Link href="/trades" className="text-gray-600 hover:text-gray-900">
+                  Trades
+                </Link>
+                <Link
+                  href="/listings/new"
+                  className="rounded-md bg-green-600 px-3 py-1.5 font-medium text-white hover:bg-green-700"
+                >
+                  Post an item
+                </Link>
                 <Link
                   href="/chat"
-                  className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                  className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 font-medium text-gray-700 hover:bg-gray-50 transition-colors"
                 >
                   <MessageSquare className="h-4 w-4" />
                   Chat
                 </Link>
-                <UserMenu email={user.email ?? ''} />
+                {isAdmin && (
+                  <Link
+                    href="/dev"
+                    className="flex items-center gap-1.5 rounded-md border border-indigo-300 bg-indigo-50 px-3 py-1.5 font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
+                  >
+                    <BarChart2 className="h-4 w-4" />
+                    Dashboard
+                  </Link>
+                )}
+                <UserMenu email={user.email ?? ''} isAdmin={isAdmin} />
               </>
             ) : (
               <>
                 <Link
                   href="/login"
-                  className="rounded-md border border-gray-300 bg-white px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                  className="rounded-md border border-gray-300 bg-white px-4 py-1.5 font-medium text-gray-700 hover:bg-gray-50 transition-colors"
                 >
                   Log In
                 </Link>
                 <Link
                   href="/register"
-                  className="rounded-md bg-green-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-green-700 transition-colors"
+                  className="rounded-md bg-green-600 px-4 py-1.5 font-semibold text-white hover:bg-green-700 transition-colors"
                 >
                   Sign Up
                 </Link>


### PR DESCRIPTION
## Summary
- Logged-in users now see **Browse, Trades, Post an item, Chat, and Profile** on the home page (`/`) — previously only Chat + avatar were shown
- Admin users additionally see the **Dashboard** (indigo) link on the home page, matching the behaviour of the `(main)` layout
- Passes `isAdmin` to `UserMenu` on the home page so the indigo admin avatar/badge renders correctly

## Changes
| File | Change |
|------|--------|
| `src/app/page.tsx` | Fetch `is_admin`, expand nav to full link set for logged-in users, conditionally render Dashboard for admins |

## Test plan
- [x] All unit tests pass (`npm run test`) — 348 tests, 14 files
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual smoke test: sign in as a regular user → home page shows Browse, Trades, Post an item, Chat, avatar; sign in as admin → Dashboard link also visible

## Security checklist
- [x] No secrets committed (Gitleaks)
- [x] RLS enabled on all tables (no new tables)
- [x] PII stripped from Groq prompts (no agent changes)
- [x] No new Server Actions — read-only `is_admin` fetch via server Supabase client
- [x] No `any` types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)