### PR TITLE
feat(trades): detail page, clickable rows, and 1-100 score form

### DIFF
--- a/src/actions/__tests__/reviews.test.ts
+++ b/src/actions/__tests__/reviews.test.ts
@@ -110,19 +110,19 @@ describe('submitReviewAction', () => {
 
   it('returns error when score is below 1', async () => {
     const result = await submitReviewAction(TRADE_ID, 0, null)
-    expect(result.error).toMatch(/1 and 5/i)
+    expect(result.error).toMatch(/1 and 100/i)
     expect(mockReviewInsert).not.toHaveBeenCalled()
   })
 
-  it('returns error when score is above 5', async () => {
-    const result = await submitReviewAction(TRADE_ID, 6, null)
-    expect(result.error).toMatch(/1 and 5/i)
+  it('returns error when score is above 100', async () => {
+    const result = await submitReviewAction(TRADE_ID, 101, null)
+    expect(result.error).toMatch(/1 and 100/i)
     expect(mockReviewInsert).not.toHaveBeenCalled()
   })
 
   it('returns error when score is not an integer', async () => {
-    const result = await submitReviewAction(TRADE_ID, 3.5, null)
-    expect(result.error).toMatch(/1 and 5/i)
+    const result = await submitReviewAction(TRADE_ID, 50.5, null)
+    expect(result.error).toMatch(/1 and 100/i)
     expect(mockReviewInsert).not.toHaveBeenCalled()
   })
 
@@ -157,19 +157,21 @@ describe('submitReviewAction', () => {
     expect(mockReviewInsert).not.toHaveBeenCalled()
   })
 
-  // ── User is not counterparty ────────────────────────────────────────────────
+  // ── Party restrictions ──────────────────────────────────────────────────────
 
-  it('returns error when user is not the counterparty (initiator tries to review)', async () => {
+  it('allows initiator to review (reviewee is counterparty)', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: INITIATOR_ID } } })
-    const result = await submitReviewAction(TRADE_ID, 4, 'Great!')
-    expect(result.error).toMatch(/lender/i)
-    expect(mockReviewInsert).not.toHaveBeenCalled()
+    const result = await submitReviewAction(TRADE_ID, 75, 'Great!')
+    expect(result.error).toBeNull()
+    const payload = mockReviewInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.reviewer_id).toBe(INITIATOR_ID)
+    expect(payload.reviewee_id).toBe(COUNTERPARTY_ID)
   })
 
   it('returns error when user is unrelated to the trade', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'stranger-user-999' } } })
-    const result = await submitReviewAction(TRADE_ID, 4, 'Great!')
-    expect(result.error).toMatch(/lender/i)
+    const result = await submitReviewAction(TRADE_ID, 50, 'Great!')
+    expect(result.error).toMatch(/not a party/i)
     expect(mockReviewInsert).not.toHaveBeenCalled()
   })
 

--- a/src/actions/reviews.ts
+++ b/src/actions/reviews.ts
@@ -1,7 +1,7 @@
 'use server'
 
 // src/actions/reviews.ts
-// Server Action for submitting a trade review.
+// Server Actions for submitting a trade review.
 
 import { createClient } from '@/lib/supabase/server'
 import { runSentiment } from '@/lib/agents/sentiment'
@@ -10,6 +10,13 @@ export interface SubmitReviewResult {
   error: string | null
 }
 
+// ---------------------------------------------------------------------------
+// submitReviewAction — callable programmatically (tradeId, score, comment)
+//
+// Either party to a completed trade may review the other.
+// Duplicate reviews are blocked by the UNIQUE(trade_id, reviewer_id) DB
+// constraint; we also do a pre-flight check to give a clear error message.
+// ---------------------------------------------------------------------------
 export async function submitReviewAction(
   tradeId: string,
   score: number,
@@ -25,8 +32,8 @@ export async function submitReviewAction(
 
   // 2. Validate inputs
   if (!tradeId) return { error: 'Trade ID is required.' }
-  if (!Number.isInteger(score) || score < 1 || score > 5) {
-    return { error: 'Score must be an integer between 1 and 5.' }
+  if (!Number.isInteger(score) || score < 1 || score > 100) {
+    return { error: 'Score must be an integer between 1 and 100.' }
   }
 
   // 3. Fetch the trade and verify eligibility
@@ -45,14 +52,18 @@ export async function submitReviewAction(
     counterparty_id: string
   }
 
-  // Only counterparty (lender) can review after completion
   if (t.status !== 'completed') {
     return { error: 'Reviews can only be submitted for completed trades.' }
   }
 
-  if (t.counterparty_id !== user.id) {
-    return { error: 'Only the lender can leave a review for this trade.' }
+  const isInitiator = t.initiator_id === user.id
+  const isCounterparty = t.counterparty_id === user.id
+  if (!isInitiator && !isCounterparty) {
+    return { error: 'You are not a party to this trade.' }
   }
+
+  // Reviewer reviews the other party
+  const reviewee_id = isInitiator ? t.counterparty_id : t.initiator_id
 
   // 4. Check for duplicate review
   const { data: existing } = await supabase
@@ -79,8 +90,6 @@ export async function submitReviewAction(
   }
 
   // 6. Insert the review
-  const reviewee_id = t.initiator_id
-
   const { error: insertError } = await supabase.from('reviews').insert({
     trade_id: tradeId,
     reviewer_id: user.id,
@@ -91,7 +100,6 @@ export async function submitReviewAction(
   })
 
   if (insertError) {
-    // 23505 = unique_violation — duplicate review race condition
     if (insertError.code === '23505') {
       return { error: 'You have already submitted a review for this trade.' }
     }
@@ -102,4 +110,26 @@ export async function submitReviewAction(
   await supabase.rpc('recalculate_trust_score', { p_user_id: reviewee_id })
 
   return { error: null }
+}
+
+// ---------------------------------------------------------------------------
+// submitReviewFormAction — useActionState-compatible wrapper
+// Reads trade_id, score, and comment from FormData.
+// ---------------------------------------------------------------------------
+export async function submitReviewFormAction(
+  _prevState: SubmitReviewResult,
+  formData: FormData
+): Promise<SubmitReviewResult> {
+  const tradeId = formData.get('trade_id')
+  const scoreRaw = formData.get('score')
+  const comment = formData.get('comment')
+
+  if (typeof tradeId !== 'string' || !tradeId) {
+    return { error: 'Invalid trade.' }
+  }
+
+  const score = Number(scoreRaw)
+  const commentStr = typeof comment === 'string' && comment.trim() ? comment.trim() : null
+
+  return submitReviewAction(tradeId, score, commentStr)
 }

--- a/src/app/(main)/trades/[id]/page.tsx
+++ b/src/app/(main)/trades/[id]/page.tsx
@@ -1,0 +1,250 @@
+// src/app/(main)/trades/[id]/page.tsx
+// Trade detail page — shows full trade info and scoring form for completed trades.
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import {
+  ArrowLeft,
+  MessageSquare,
+  Clock,
+  CheckCircle,
+  AlertTriangle,
+  XCircle,
+  ArrowRightLeft,
+  Activity,
+  CalendarCheck,
+} from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
+import TradeScoreForm from '@/components/TradeScoreForm'
+import type { Trade, TradeStatus } from '@/types/trades'
+import type { Review } from '@/types/reviews'
+
+export const metadata: Metadata = {
+  title: 'Trade Detail — NeighborSwap',
+}
+
+// ── Status display config ─────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  TradeStatus,
+  { label: string; color: string; Icon: React.ElementType }
+> = {
+  pending_offer: {
+    label: 'Pending offer',
+    color: 'text-yellow-700 bg-yellow-50 border-yellow-200',
+    Icon: Clock,
+  },
+  negotiating: {
+    label: 'Negotiating',
+    color: 'text-blue-700 bg-blue-50 border-blue-200',
+    Icon: ArrowRightLeft,
+  },
+  accepted: {
+    label: 'Accepted',
+    color: 'text-green-700 bg-green-50 border-green-200',
+    Icon: CheckCircle,
+  },
+  flagged: {
+    label: 'Flagged',
+    color: 'text-red-700 bg-red-50 border-red-200',
+    Icon: AlertTriangle,
+  },
+  scheduled: {
+    label: 'Scheduled',
+    color: 'text-indigo-700 bg-indigo-50 border-indigo-200',
+    Icon: CalendarCheck,
+  },
+  in_progress: {
+    label: 'In progress',
+    color: 'text-purple-700 bg-purple-50 border-purple-200',
+    Icon: Activity,
+  },
+  completed: {
+    label: 'Completed',
+    color: 'text-gray-700 bg-gray-50 border-gray-200',
+    Icon: CheckCircle,
+  },
+  cancelled: {
+    label: 'Cancelled',
+    color: 'text-gray-500 bg-gray-50 border-gray-200',
+    Icon: XCircle,
+  },
+  disputed: {
+    label: 'Disputed',
+    color: 'text-orange-700 bg-orange-50 border-orange-200',
+    Icon: AlertTriangle,
+  },
+}
+
+function StatusBadge({ status }: { status: TradeStatus }) {
+  const { label, color, Icon } = STATUS_CONFIG[status] ?? STATUS_CONFIG.pending_offer
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium ${color}`}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+      {label}
+    </span>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5 sm:flex-row sm:items-start sm:gap-4">
+      <dt className="w-36 shrink-0 text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-sm text-gray-800">{value}</dd>
+    </div>
+  )
+}
+
+function fmt(iso: string | null) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function TradeDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  // Fetch trade
+  const { data: rawTrade } = await supabase.from('trades').select('*').eq('id', id).single()
+  if (!rawTrade) notFound()
+
+  const trade = rawTrade as Trade
+
+  // Ensure the current user is a party to this trade
+  if (trade.initiator_id !== user.id && trade.counterparty_id !== user.id) notFound()
+
+  // Fetch item title and other party's name in parallel
+  const otherPartyId = trade.initiator_id === user.id ? trade.counterparty_id : trade.initiator_id
+
+  const [itemResult, otherPartyResult, myReviewResult] = await Promise.all([
+    supabase.from('items').select('title').eq('id', trade.item_id).single(),
+    supabase.from('users').select('full_name').eq('id', otherPartyId).single(),
+    // Check if the current user already reviewed this trade
+    supabase
+      .from('reviews')
+      .select('score, comment, created_at')
+      .eq('trade_id', id)
+      .eq('reviewer_id', user.id)
+      .maybeSingle(),
+  ])
+
+  const itemTitle = (itemResult.data as { title: string } | null)?.title ?? 'Unknown item'
+  const otherPartyName =
+    (otherPartyResult.data as { full_name: string | null } | null)?.full_name ?? 'Unknown user'
+  const myReview = myReviewResult.data as Review | null
+
+  const role = trade.initiator_id === user.id ? 'Initiator' : 'Counterparty'
+  const isCompleted = trade.status === 'completed'
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/trades"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        My trades
+      </Link>
+
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">
+            Trade #{trade.id.slice(0, 8).toUpperCase()}
+          </h1>
+          <p className="mt-0.5 text-sm text-gray-500">{itemTitle}</p>
+        </div>
+        <StatusBadge status={trade.status} />
+      </div>
+
+      {/* Details card */}
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <dl className="space-y-3">
+          <DetailRow label="Your role" value={role} />
+          <DetailRow label="Other party" value={otherPartyName} />
+          {trade.agreed_terms && <DetailRow label="Agreed terms" value={trade.agreed_terms} />}
+          {trade.vibe_score !== null && (
+            <DetailRow
+              label="Vibe score"
+              value={<span className="font-semibold text-indigo-600">{trade.vibe_score}/100</span>}
+            />
+          )}
+          <DetailRow label="Created" value={fmt(trade.created_at)} />
+          {trade.accepted_at && <DetailRow label="Accepted" value={fmt(trade.accepted_at)} />}
+          {trade.scheduled_at && <DetailRow label="Scheduled" value={fmt(trade.scheduled_at)} />}
+          {trade.completed_at && <DetailRow label="Completed" value={fmt(trade.completed_at)} />}
+          {trade.cancelled_at && <DetailRow label="Cancelled" value={fmt(trade.cancelled_at)} />}
+          {trade.cancellation_reason && (
+            <DetailRow label="Cancel reason" value={trade.cancellation_reason} />
+          )}
+          {trade.dispute_reason && (
+            <DetailRow label="Dispute reason" value={trade.dispute_reason} />
+          )}
+        </dl>
+      </div>
+
+      {/* Chat link */}
+      <Link
+        href={`/chat/${trade.id}`}
+        className="flex items-center justify-center gap-2 rounded-xl border border-gray-300 bg-white py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors shadow-sm"
+      >
+        <MessageSquare className="h-4 w-4" aria-hidden />
+        Open chat for this trade
+      </Link>
+
+      {/* Score section — only for completed trades */}
+      {isCompleted && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Your review
+          </h2>
+
+          {myReview ? (
+            /* Already reviewed — show the submitted score */
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-gray-600">
+                  You scored this trade on{' '}
+                  {new Date(myReview.created_at).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </span>
+                <span className="text-2xl font-bold text-green-600">
+                  {myReview.score}
+                  <span className="text-sm font-normal text-gray-400">/100</span>
+                </span>
+              </div>
+              {myReview.comment && (
+                <p className="mt-3 rounded-lg bg-gray-50 px-4 py-3 text-sm text-gray-700 italic">
+                  &ldquo;{myReview.comment}&rdquo;
+                </p>
+              )}
+            </div>
+          ) : (
+            /* Not yet reviewed — show the form */
+            <TradeScoreForm tradeId={trade.id} />
+          )}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/app/(main)/trades/page.tsx
+++ b/src/app/(main)/trades/page.tsx
@@ -2,6 +2,7 @@
 // Trades dashboard — shows the current user's active and completed trades.
 
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { ArrowRightLeft, Clock, CheckCircle, AlertTriangle, XCircle } from 'lucide-react'
@@ -119,19 +120,24 @@ function TradeRow({ trade, userId }: { trade: Trade; userId: string }) {
   })
 
   return (
-    <li className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm">
-      <div className="min-w-0">
-        <p className="truncate text-sm font-medium text-gray-900">
-          Trade #{trade.id.slice(0, 8).toUpperCase()}
-        </p>
-        <p className="mt-0.5 text-xs text-gray-400">
-          {role} · Updated {updatedAt}
-        </p>
-        {trade.vibe_score !== null && (
-          <p className="mt-0.5 text-xs text-indigo-500">Vibe score: {trade.vibe_score}/100</p>
-        )}
-      </div>
-      <StatusBadge status={trade.status} />
+    <li>
+      <Link
+        href={`/trades/${trade.id}`}
+        className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm hover:border-gray-300 hover:bg-gray-50 transition-colors"
+      >
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-gray-900">
+            Trade #{trade.id.slice(0, 8).toUpperCase()}
+          </p>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {role} · Updated {updatedAt}
+          </p>
+          {trade.vibe_score !== null && (
+            <p className="mt-0.5 text-xs text-indigo-500">Vibe score: {trade.vibe_score}/100</p>
+          )}
+        </div>
+        <StatusBadge status={trade.status} />
+      </Link>
     </li>
   )
 }

--- a/src/components/TradeScoreForm.tsx
+++ b/src/components/TradeScoreForm.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+import { Star } from 'lucide-react'
+import { submitReviewFormAction } from '@/actions/reviews'
+
+interface TradeScoreFormProps {
+  tradeId: string
+}
+
+const initialState = { error: null }
+
+export default function TradeScoreForm({ tradeId }: TradeScoreFormProps) {
+  const [score, setScore] = useState(50)
+  const [submitted, setSubmitted] = useState(false)
+  const [state, formAction, pending] = useActionState(submitReviewFormAction, initialState)
+
+  const scoreColor =
+    score >= 75 ? 'text-green-600' : score >= 50 ? 'text-amber-600' : 'text-red-500'
+
+  if (submitted && !pending && state.error === null) {
+    return (
+      <div className="rounded-xl border border-green-200 bg-green-50 p-5">
+        <div className="mb-1 flex items-center gap-2">
+          <Star className="h-4 w-4 text-amber-500 fill-amber-500" aria-hidden />
+          <span className="text-sm font-semibold text-green-800">Score submitted</span>
+        </div>
+        <p className="text-sm text-green-700">
+          You gave this trade a score of <strong className="text-green-800">{score}/100</strong>.
+          Thank you!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-4 flex items-center gap-2">
+        <Star className="h-4 w-4 text-amber-500" aria-hidden />
+        <h2 className="text-sm font-semibold text-gray-800">Score this trade</h2>
+      </div>
+
+      <form action={formAction} onSubmit={() => setSubmitted(true)}>
+        <input type="hidden" name="trade_id" value={tradeId} />
+        <input type="hidden" name="score" value={score} />
+
+        {/* Slider */}
+        <div className="mb-5">
+          <div className="mb-1 flex items-baseline justify-between">
+            <label className="text-xs font-medium text-gray-600" htmlFor="score-slider">
+              Score
+            </label>
+            <span className={`text-2xl font-bold tabular-nums ${scoreColor}`}>
+              {score}
+              <span className="text-sm font-normal text-gray-400">/100</span>
+            </span>
+          </div>
+          <input
+            id="score-slider"
+            type="range"
+            min={1}
+            max={100}
+            step={1}
+            value={score}
+            onChange={(e) => setScore(Number(e.target.value))}
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-gray-200 accent-green-600"
+          />
+          <div className="mt-1 flex justify-between text-xs text-gray-400">
+            <span>1 — Poor</span>
+            <span>50 — OK</span>
+            <span>100 — Excellent</span>
+          </div>
+        </div>
+
+        {/* Optional comment */}
+        <div className="mb-4">
+          <label htmlFor="trade-comment" className="mb-1 block text-xs font-medium text-gray-600">
+            Comment <span className="text-gray-400">(optional)</span>
+          </label>
+          <textarea
+            id="trade-comment"
+            name="comment"
+            rows={3}
+            maxLength={500}
+            placeholder="How did the exchange go?"
+            className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+          />
+        </div>
+
+        {state.error && <p className="mb-3 text-xs text-red-600">{state.error}</p>}
+
+        <button
+          type="submit"
+          disabled={pending}
+          className="w-full rounded-lg bg-green-600 py-2 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
+        >
+          {pending ? 'Submitting…' : 'Submit score'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/types/reviews.ts
+++ b/src/types/reviews.ts
@@ -6,7 +6,7 @@ export interface Review {
   trade_id: string
   reviewer_id: string
   reviewee_id: string
-  score: number // 1–5
+  score: number // 1–100
   comment: string | null
   sentiment_score: number | null // 0–100
   created_at: string // ISO-8601
@@ -14,6 +14,10 @@ export interface Review {
 
 export interface SubmitReviewInput {
   trade_id: string
-  score: number
+  score: number // 1–100
   comment: string | null
+}
+
+export interface SubmitReviewResult {
+  error: string | null
 }

--- a/supabase/migrations/20260422000000_widen_review_score_to_100.sql
+++ b/supabase/migrations/20260422000000_widen_review_score_to_100.sql
@@ -1,0 +1,24 @@
+-- supabase/migrations/20260422000000_widen_review_score_to_100.sql
+-- Widen reviews.score constraint from 1–5 to 1–100 so users can give
+-- a fine-grained score. recalculate_trust_score updated for the new scale.
+
+ALTER TABLE public.reviews DROP CONSTRAINT IF EXISTS reviews_score_check;
+ALTER TABLE public.reviews ADD CONSTRAINT reviews_score_check CHECK (score BETWEEN 1 AND 100);
+
+-- Recalculate trust_score directly on the 1-100 scale (was: avg/5*100)
+CREATE OR REPLACE FUNCTION public.recalculate_trust_score(p_user_id UUID)
+RETURNS void AS $$
+DECLARE
+  avg_score NUMERIC;
+BEGIN
+  SELECT AVG(score) INTO avg_score
+  FROM public.reviews
+  WHERE reviewee_id = p_user_id;
+
+  IF avg_score IS NOT NULL THEN
+    UPDATE public.users
+    SET trust_score = LEAST(100, GREATEST(0, ROUND(avg_score)))
+    WHERE id = p_user_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Every trade row in `/trades` is now a clickable link to `/trades/[id]`
- New trade detail page (`/trades/[id]`) shows status, parties, timestamps, agreed terms, vibe score, and an **Open Chat** button
- Completed trades display a **1–100 score slider form** (TradeScoreForm); if the user already reviewed, their submitted score and comment are shown instead
- Both initiator **and** counterparty can now score a completed trade (reviewer scores the other party); previously only the counterparty could review
- DB migration widens `reviews.score` constraint from `1–5` → `1–100` and updates `recalculate_trust_score` for the new scale
- Added `submitReviewFormAction` (useActionState-compatible) alongside the existing `submitReviewAction`

## Changes
| File | Change |
|------|--------|
| `src/app/(main)/trades/page.tsx` | Wrap each `TradeRow` in `<Link href="/trades/[id]">` |
| `src/app/(main)/trades/[id]/page.tsx` | **New** — trade detail server component |
| `src/components/TradeScoreForm.tsx` | **New** — 1-100 slider client component with success state |
| `src/actions/reviews.ts` | Allow both parties to review; widen score to 1-100; add form action |
| `src/types/reviews.ts` | Update `score` doc comment to `1–100`; export `SubmitReviewResult` |
| `src/actions/__tests__/reviews.test.ts` | Update range assertions; add initiator-review test |
| `supabase/migrations/20260422000000_widen_review_score_to_100.sql` | **New** — schema migration |

## Test plan
- [x] All unit tests pass (`npm run test`) — 348 tests, 14 files
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`) — `/trades/[id]` route appears
- [ ] Manual smoke test:
  1. Log in → go to `/trades` → click any trade row → lands on detail page
  2. For a completed trade: score slider appears (1–100); submit → success banner
  3. Reload the completed trade detail → existing review shown (no form)
  4. Admin: same flows work with admin account

## Security checklist
- [x] No secrets committed (Gitleaks)
- [x] RLS enabled on all tables (no new tables; existing `reviews` RLS unchanged)
- [x] PII stripped from Groq prompts (sentiment agent unchanged)
- [x] Server Actions validate score range and party membership before insert
- [x] No `any` types introduced (only narrowing casts for Supabase join results)
- [x] `/trades/[id]` enforces auth + party membership — non-parties get 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)