### PR TITLE
chore(ci): improve review-pr skill — upstream-check and PR-exists guard

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -52,14 +52,14 @@ Only proceed to Step 2 when all four gates pass (or the user explicitly acknowle
 
 ---
 
-### Step 2 — Stage, commit, and push
+### Step 2 — Stage, commit, and push to GitHub
 
 1. Run `git status` and `git diff` to review all uncommitted changes.
 2. Run `git log --oneline -10` to understand the recent commit history and match the project's commit message style.
-3. Stage only relevant files — do **not** use `git add -A` or `git add .` blindly. Exclude:
+3. If there are uncommitted changes, stage only relevant files — do **not** use `git add -A` or `git add .` blindly. Exclude:
    - `.env*`, `*.local`, credential files
    - Large binaries unrelated to the feature
-4. Write a concise commit message (imperative mood, ≤72 chars subject line) and commit:
+4. If there are staged changes, write a concise commit message (imperative mood, ≤72 chars subject line) and commit:
 
 ```bash
 git commit -m "$(cat <<'EOF'
@@ -72,20 +72,39 @@ EOF
 )"
 ```
 
-5. Push the branch to the remote:
+5. Push the branch to GitHub. Check whether an upstream is already configured:
 
 ```bash
-git push -u origin <branch-name>
+# Check if upstream is set
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
 ```
+
+- If **no upstream** is set (command fails or returns nothing), push and set it:
+  ```bash
+  git push -u origin <branch-name>
+  ```
+- If **upstream is already set**, push normally:
+  ```bash
+  git push
+  ```
+
+Confirm the push succeeded before continuing.
 
 ---
 
-### Step 3 — Create the pull request
+### Step 3 — Create the pull request on GitHub
 
-Create the PR using `gh pr create`:
+First check whether a PR already exists for this branch:
 
 ```bash
-gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
+gh pr view --json url,state 2>/dev/null
+```
+
+- If a PR **already exists** and is open, skip creation and report the existing PR URL to the user. Proceed to Step 4.
+- If **no open PR exists**, create one:
+
+```bash
+gh pr create --title "<concise title under 70 chars>" --base main --body "$(cat <<'EOF'
 ## Summary
 - <bullet 1>
 - <bullet 2>
@@ -115,7 +134,7 @@ EOF
 )"
 ```
 
-Report the PR URL to the user.
+Report the PR URL to the user before continuing.
 
 ---
 

--- a/.claude/skills/review-pr.md
+++ b/.claude/skills/review-pr.md
@@ -52,14 +52,14 @@ Only proceed to Step 2 when all four gates pass (or the user explicitly acknowle
 
 ---
 
-### Step 2 — Stage, commit, and push
+### Step 2 — Stage, commit, and push to GitHub
 
 1. Run `git status` and `git diff` to review all uncommitted changes.
 2. Run `git log --oneline -10` to understand the recent commit history and match the project's commit message style.
-3. Stage only relevant files — do **not** use `git add -A` or `git add .` blindly. Exclude:
+3. If there are uncommitted changes, stage only relevant files — do **not** use `git add -A` or `git add .` blindly. Exclude:
    - `.env*`, `*.local`, credential files
    - Large binaries unrelated to the feature
-4. Write a concise commit message (imperative mood, ≤72 chars subject line) and commit:
+4. If there are staged changes, write a concise commit message (imperative mood, ≤72 chars subject line) and commit:
 
 ```bash
 git commit -m "$(cat <<'EOF'
@@ -72,20 +72,39 @@ EOF
 )"
 ```
 
-5. Push the branch to the remote:
+5. Push the branch to GitHub. Check whether an upstream is already configured:
 
 ```bash
-git push -u origin <branch-name>
+# Check if upstream is set
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
 ```
+
+- If **no upstream** is set (command fails or returns nothing), push and set it:
+  ```bash
+  git push -u origin <branch-name>
+  ```
+- If **upstream is already set**, push normally:
+  ```bash
+  git push
+  ```
+
+Confirm the push succeeded before continuing.
 
 ---
 
-### Step 3 — Create the pull request
+### Step 3 — Create the pull request on GitHub
 
-Create the PR using `gh pr create`:
+First check whether a PR already exists for this branch:
 
 ```bash
-gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
+gh pr view --json url,state 2>/dev/null
+```
+
+- If a PR **already exists** and is open, skip creation and report the existing PR URL to the user. Proceed to Step 4.
+- If **no open PR exists**, create one:
+
+```bash
+gh pr create --title "<concise title under 70 chars>" --base main --body "$(cat <<'EOF'
 ## Summary
 - <bullet 1>
 - <bullet 2>
@@ -115,7 +134,7 @@ EOF
 )"
 ```
 
-Report the PR URL to the user.
+Report the PR URL to the user before continuing.
 
 ---
 


### PR DESCRIPTION
## Summary
- Step 2 now checks for an existing upstream before pushing — uses \`git push -u origin <branch>\` only when no upstream is configured, plain \`git push\` otherwise, avoiding a misleading error on branches already tracking a remote
- Step 3 now runs \`gh pr view --json url,state\` before calling \`gh pr create\` — if an open PR already exists for the branch it is reported back and creation is skipped, preventing duplicate PRs

## Changes
| File | Change |
|------|--------|
| \`.claude/skills/review-pr.md\` | Add upstream-check logic (Step 2); add open-PR guard (Step 3) |
| \`.claude/commands/review-pr.md\` | Same changes (commands mirror skills) |

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`) ✅
- [ ] Unit tests pass (`npm run test`) ✅ — 348 tests
- [ ] Lint passes (`npm run lint`) ✅
- [ ] Build succeeds (`npm run build`) ✅
- [ ] No product code changed — CI gates confirm no regressions

## Security checklist
- [x] No secrets committed
- [x] No Supabase tables added or modified
- [x] Markdown-only change — no server code touched
- [x] No `any` types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)